### PR TITLE
Warn before applying empty value in bulk edit

### DIFF
--- a/src/bulk-edit-modal.ts
+++ b/src/bulk-edit-modal.ts
@@ -254,7 +254,7 @@ export class BulkEditModal extends Modal {
 		const filesToUpdate = this.getCheckedFiles();
 
 		if (type !== "checkbox" && this.rawValue.trim() === "") {
-			const confirmed = await confirmEmptyValue(this.app, property, type, filesToUpdate.length);
+			const confirmed = await confirmEmptyValue(this.app, property, filesToUpdate.length);
 			if (!confirmed) {
 				this.uiLocked = false;
 				this.setUIEnabled(true);

--- a/src/confirm-modal.ts
+++ b/src/confirm-modal.ts
@@ -40,19 +40,13 @@ class ConfirmModal extends Modal {
 	}
 }
 
-const LIST_TYPES = new Set(["tags", "aliases", "multitext"]);
-
 export function confirmEmptyValue(
 	app: App,
 	property: string,
-	type: string,
 	fileCount: number,
 ): Promise<boolean> {
 	const noun = fileCount === 1 ? "file" : "files";
-	const effect = LIST_TYPES.has(type)
-		? `remove all values from "${property}"`
-		: `set "${property}" to blank`;
-	const message = `New value is empty. This will ${effect} on ${fileCount} ${noun}.`;
+	const message = `New value is empty. This will clear "${property}" on ${fileCount} ${noun}.`;
 	return new Promise<boolean>(resolve => {
 		new ConfirmModal(app, message, resolve).open();
 	});


### PR DESCRIPTION
## Summary

- Show a confirmation dialog when the user clicks Update with an empty value, stating how many files will be affected
- Confirmation runs after pending file-selection saves settle, so the count is accurate
- Checkbox properties are excluded (they always have a value)

## Test plan

- [ ] Open bulk edit modal with multiple files selected
- [ ] Leave "New value" empty and click Update — confirmation dialog should appear with correct file count
- [ ] Click Cancel — no files should be modified, UI should re-enable
- [ ] Click Continue — files should be updated as before
- [ ] Toggle a file checkbox while it's saving, then immediately click Update with empty value — confirm the count matches the final selection
- [ ] Select a checkbox-type property, leave default (false), click Update — no confirmation should appear