### PR TITLE
Add cancelable progress notice to bulk property updates

### DIFF
--- a/src/bulk-edit-modal.ts
+++ b/src/bulk-edit-modal.ts
@@ -286,18 +286,13 @@ export class BulkEditModal extends Modal {
 		);
 
 		const {succeeded, failed, cancelled, total} = result;
+		let msg = `Updated "${property}" in ${succeeded} file${succeeded === 1 ? "" : "s"}`;
 		if (cancelled) {
-			new Notice(
-				`Updated "${property}" in ${succeeded} of ${total} file${total === 1 ? "" : "s"} (cancelled)`,
-			);
-		} else if (failed.length === 0) {
-			new Notice(
-				`Updated "${property}" in ${succeeded} file${succeeded === 1 ? "" : "s"}`,
-			);
-		} else {
-			new Notice(
-				`Updated ${succeeded} file${succeeded === 1 ? "" : "s"}, failed on ${failed.length}: ${failed.join(", ")}`,
-			);
+			msg = `Updated "${property}" in ${succeeded} of ${total} file${total === 1 ? "" : "s"} (cancelled)`;
 		}
+		if (failed.length > 0) {
+			msg += `, failed on ${failed.length}: ${failed.join(", ")}`;
+		}
+		new Notice(msg);
 	}
 }


### PR DESCRIPTION
## Summary
- Bulk property updates in the edit modal now show a progress notice with a cancel button, matching the UX of the deselect-all and remove-selection-property commands
- Uses the existing `withProgress()` utility — no new progress infrastructure
- Completion notice reports both cancelled status and failure details independently, so partial failures aren't hidden by cancellation

## Test plan
- [ ] Open bulk edit modal, apply a property change → progress notice appears with cancel button and file counter
- [ ] Cancel mid-operation → notice reports partial update count with "(cancelled)"
- [ ] Let update complete → notice reports success with file count
- [ ] Test with deselect-when-finished enabled → property set and selection cleared
- [ ] Enter empty value for non-checkbox property, decline confirmation → modal stays open with state intact