### PR TITLE
Remember last selected property in bulk edit dialog

### DIFF
--- a/src/bulk-edit-modal.ts
+++ b/src/bulk-edit-modal.ts
@@ -83,7 +83,9 @@ export class BulkEditModal extends Modal {
 			return;
 		}
 
-		this.selectedProperty = editableProperties[0]?.name ?? "";
+		const lastSelected = settings.lastSelectedProperty;
+		const rememberedExists = lastSelected && editableProperties.some(p => p.name === lastSelected);
+		this.selectedProperty = rememberedExists ? lastSelected : editableProperties[0]?.name ?? "";
 
 		new Setting(contentEl)
 			.setName("Property")
@@ -266,6 +268,9 @@ export class BulkEditModal extends Modal {
 		const value = coerceValue(this.rawValue, type);
 		const selProp = this.plugin.settings.selectionProperty;
 		const deselect = this.deselectWhenFinished;
+
+		this.plugin.settings.lastSelectedProperty = property;
+		await this.plugin.saveSettings();
 
 		this.close();
 

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -54,12 +54,14 @@ export interface BulkPropertiesSettings {
 	deselectWhenFinished: boolean;
 	selectionProperty: string;
 	properties: PropertyConfig[];
+	lastSelectedProperty: string;
 }
 
 export const DEFAULT_SETTINGS: BulkPropertiesSettings = {
 	deselectWhenFinished: true,
 	selectionProperty: "selected",
 	properties: [],
+	lastSelectedProperty: "",
 };
 
 export class BulkPropertiesSettingTab extends PluginSettingTab {


### PR DESCRIPTION
## Summary
- Persist the property dropdown selection when the user clicks Update, so the same property is pre-selected next time the dialog opens
- Falls back to the first available editable property if the remembered one has been removed from settings

## Test plan
- [ ] Open bulk edit dialog, select a non-default property, click Update. Reopen dialog — should show the property you updated with
- [ ] Open bulk edit dialog, change property selection, close without clicking Update. Reopen — should NOT remember the change
- [ ] Remove the remembered property from plugin settings, reopen dialog — should fall back to the first available editable property