### PR TITLE
Add select all / deselect all buttons to bulk edit dialog

### DIFF
--- a/src/bulk-edit-modal.ts
+++ b/src/bulk-edit-modal.ts
@@ -303,7 +303,9 @@ export class BulkEditModal extends Modal {
 		}
 		if (this.selectAllBtn) this.selectAllBtn.disabled = !enabled;
 		if (this.deselectAllBtn) this.deselectAllBtn.disabled = !enabled;
-		if (this.updateBtn) this.updateBtn.disabled = !enabled;
+		if (this.updateBtn) {
+			this.updateBtn.disabled = !enabled || this.getCheckedFiles().length === 0;
+		}
 	}
 
 	private async doUpdate() {


### PR DESCRIPTION
## Summary
- Add "Select all" and "Deselect all" buttons below the file list in the bulk edit dialog
- Buttons disable all UI controls during operation to prevent interleaving with individual toggles
- Extract shared `writeSelection()` helper for frontmatter writes used by both single toggles and bulk operations
- Disable the Update button when no files are selected; re-enable when any file is checked
- Fix unhandled `saveSettings()` rejection in `doUpdate()` that could leave the modal locked

## Test plan
- [ ] Open Bulk Edit dialog with multiple selected files
- [ ] Click "Deselect all" — all checkboxes uncheck, count updates to 0, Update button is disabled
- [ ] Click "Select all" — all checkboxes check, count updates, Update button re-enables
- [ ] Verify buttons are disabled while a bulk operation is in progress
- [ ] Verify buttons are disabled during an Update operation
- [ ] Manually uncheck all files one by one — Update button disables when last file is unchecked
- [ ] Re-check a file — Update button re-enables
- [ ] Open dialog with files but no editable properties configured — no runtime errors