### PR TITLE
Drop misleading "all" from remove property confirmation

### DIFF
--- a/src/remove-selection-property.ts
+++ b/src/remove-selection-property.ts
@@ -29,7 +29,7 @@ class ConfirmRemoveModal extends Modal {
 
 		const n = this.fileCount;
 		contentEl.createEl("p", {
-			text: `This will modify all ${n} file${n === 1 ? "" : "s"} in your vault by removing the "${this.property}" property from them. Are you sure?`,
+			text: `This will modify ${n} file${n === 1 ? "" : "s"} in your vault by removing the "${this.property}" property from them. Are you sure?`,
 		});
 
 		new Setting(contentEl)


### PR DESCRIPTION
## Summary
- Remove the word "all" from the confirmation dialog when removing the selection property. The previous wording ("all N files") implied the entire vault was affected, when only the subset with the property is modified.

## Test plan
- [ ] Open a vault where only some files have the selection property
- [ ] Run the "Remove selection property" command
- [ ] Verify the confirmation says "This will modify N files in your vault..." without "all"