### PR TITLE
Require explicit type selection before adding a property

### DIFF
--- a/src/settings.ts
+++ b/src/settings.ts
@@ -157,19 +157,16 @@ export class BulkPropertiesSettingTab extends PluginSettingTab {
 					}
 				}));
 
-		new Setting(containerEl)
+		const propertiesHeading = new Setting(containerEl)
 			.setName("Properties")
-			.then(setting => {
-					setting.descEl.empty();
-					setting.descEl.appendText(
-						"Configure which properties are available for bulk editing.",
-					);
-					setting.descEl.createEl("br");
-					setting.descEl.createEl("strong", {
-						text: "You must add at least one property to use the bulk-editing feature.",
-					});
-				})
 			.setHeading();
+		propertiesHeading.descEl.appendText(
+			"Configure which properties are available for bulk editing.",
+		);
+		propertiesHeading.descEl.createEl("br");
+		propertiesHeading.descEl.createEl("strong", {
+			text: "You must add at least one property to use the bulk-editing feature.",
+		});
 
 		for (let i = 0; i < this.plugin.settings.properties.length; i++) {
 			const prop = this.plugin.settings.properties[i]!;


### PR DESCRIPTION
## Summary

- The type dropdown in "Add property" now starts with a disabled "Choose type…" placeholder instead of defaulting to "text", preventing accidental text properties
- The Add button is disabled until both a property name and a valid type are selected
- The Properties heading description now includes bold guidance that at least one property is required

## Test plan

- [ ] Open Settings → Bulk Properties → Add property row shows "Choose type…" and disabled Add button
- [ ] Type a name only → button stays disabled
- [ ] Pick a type only → button stays disabled
- [ ] Both name and type filled → button enables
- [ ] Select a name via autocomplete suggestion → button enables (if type also set)
- [ ] Clear the name → button disables again
- [ ] Add a duplicate name → Notice appears, property not added
- [ ] Properties heading shows bold "You must add at least one property" on a second line