### PR TITLE
Auto-detect property type in settings

### DIFF
--- a/src/settings.ts
+++ b/src/settings.ts
@@ -212,6 +212,7 @@ export class BulkPropertiesSettingTab extends PluginSettingTab {
 		let newType: PropertyType | "" = "";
 		let addBtn: ButtonComponent | undefined;
 		let typeDropdown: DropdownComponent;
+		let lastDetectedName = "";
 
 		function updateAddButton(): void {
 			addBtn?.setDisabled(
@@ -221,6 +222,8 @@ export class BulkPropertiesSettingTab extends PluginSettingTab {
 
 		const tryAutoDetect = (): void => {
 			const name = nameInputEl.value.trim();
+			if (name === lastDetectedName) return;
+			lastDetectedName = name;
 			if (name === "") {
 				newType = "";
 				typeDropdown.setValue("");


### PR DESCRIPTION
## Summary

- When adding a property in settings, auto-detect its type from Obsidian's internal `metadataTypeManager.getPropertyInfo()` API and pre-select the type dropdown
- Detection triggers on autocomplete suggestion select and name input blur, but only when the name has actually changed
- User can still manually override the detected type — subsequent blur events without a name change preserve the override
- Falls back silently to manual selection if the API is unavailable, the property is unknown, or the type is unrecognized

## Test plan

- [ ] Add a property by selecting from autocomplete (e.g. "due") — type dropdown should auto-select the correct type
- [ ] Type a known property name and tab out — type dropdown should auto-select
- [ ] Type an unknown property name and tab out — dropdown stays on "Choose type..."
- [ ] Auto-detect a type, manually override the dropdown, then blur the name field without changing it — manual override should be preserved
- [ ] Change the property name after a type is set — dropdown should re-detect for the new name
- [ ] Verify lint (`npm run lint`) and build (`npm run build`) pass cleanly