### PR TITLE
Fix write race, add deselect confirmation, debounce status bar

### DIFF
--- a/src/bulk-edit-modal.ts
+++ b/src/bulk-edit-modal.ts
@@ -184,6 +184,10 @@ export class BulkEditModal extends Modal {
 				console.error(`bulk-properties: failed to toggle selection for ${file.path}:`, err);
 				checkbox.checked = !desired;
 				new Notice(`Failed to update selection for ${file.path}`);
+			} finally {
+				if (this.pendingSaves.get(file) === save) {
+					this.pendingSaves.delete(file);
+				}
 			}
 			this.updateCountText();
 			if (!this.uiLocked) {
@@ -204,18 +208,28 @@ export class BulkEditModal extends Modal {
 				.map(([file]) => file);
 
 			const failed: string[] = [];
-			await Promise.all(filesToChange.map(async (file) => {
-				try {
-					await this.writeSelection(file, selected);
-					const checkbox = this.fileCheckboxes.get(file);
-					if (checkbox) {
-						checkbox.checked = selected;
+			const saves = filesToChange.map((file) => {
+				const previous = this.pendingSaves.get(file) ?? Promise.resolve();
+				const save = previous.then(async () => {
+					try {
+						await this.writeSelection(file, selected);
+						const checkbox = this.fileCheckboxes.get(file);
+						if (checkbox) {
+							checkbox.checked = selected;
+						}
+					} catch (err: unknown) {
+						console.error(`bulk-properties: failed to set selection for ${file.path}:`, err);
+						failed.push(file.path);
+					} finally {
+						if (this.pendingSaves.get(file) === save) {
+							this.pendingSaves.delete(file);
+						}
 					}
-				} catch (err: unknown) {
-					console.error(`bulk-properties: failed to set selection for ${file.path}:`, err);
-					failed.push(file.path);
-				}
-			}));
+				});
+				this.pendingSaves.set(file, save);
+				return save;
+			});
+			await Promise.all(saves);
 
 			this.updateCountText();
 			if (failed.length > 0) {

--- a/src/confirm-modal.ts
+++ b/src/confirm-modal.ts
@@ -40,6 +40,17 @@ class ConfirmModal extends Modal {
 	}
 }
 
+export function confirmDeselectAll(
+	app: App,
+	fileCount: number,
+): Promise<boolean> {
+	const noun = fileCount === 1 ? "file" : "files";
+	const message = `This will deselect ${fileCount} ${noun}. Are you sure?`;
+	return new Promise<boolean>(resolve => {
+		new ConfirmModal(app, message, resolve).open();
+	});
+}
+
 export function confirmEmptyValue(
 	app: App,
 	property: string,

--- a/src/deselect-all.ts
+++ b/src/deselect-all.ts
@@ -1,4 +1,5 @@
 import {App, Notice} from "obsidian";
+import {confirmDeselectAll} from "./confirm-modal";
 import {getSelectedFiles} from "./files";
 import {withProgress} from "./progress";
 
@@ -12,6 +13,9 @@ export async function deselectAll(
 		new Notice("No files are selected");
 		return;
 	}
+
+	const confirmed = await confirmDeselectAll(app, files.length);
+	if (!confirmed) return;
 
 	const result = await withProgress(
 		files,

--- a/src/main.ts
+++ b/src/main.ts
@@ -9,6 +9,7 @@ import {isFileSelected, setSelection} from "./toggle-selection";
 export default class BulkPropertiesPlugin extends Plugin {
 	settings!: BulkPropertiesSettings;
 	private statusBarEl: HTMLElement | null = null;
+	private statusBarTimer: ReturnType<typeof setTimeout> | null = null;
 
 	override async onload() {
 		await this.loadSettings();
@@ -50,13 +51,13 @@ export default class BulkPropertiesPlugin extends Plugin {
 
 		this.registerEvent(
 			this.app.metadataCache.on("changed", () => {
-				this.updateStatusBar();
+				this.debouncedUpdateStatusBar();
 			}),
 		);
 
 		this.registerEvent(
 			this.app.vault.on("delete", () => {
-				this.updateStatusBar();
+				this.debouncedUpdateStatusBar();
 			}),
 		);
 
@@ -96,6 +97,23 @@ export default class BulkPropertiesPlugin extends Plugin {
 		this.app.workspace.onLayoutReady(() => {
 			this.updateStatusBar();
 		});
+	}
+
+	override onunload() {
+		if (this.statusBarTimer !== null) {
+			clearTimeout(this.statusBarTimer);
+			this.statusBarTimer = null;
+		}
+	}
+
+	private debouncedUpdateStatusBar(): void {
+		if (this.statusBarTimer !== null) {
+			clearTimeout(this.statusBarTimer);
+		}
+		this.statusBarTimer = setTimeout(() => {
+			this.statusBarTimer = null;
+			this.updateStatusBar();
+		}, 500);
 	}
 
 	updateStatusBar(): void {


### PR DESCRIPTION
## Release Notes

- **Added confirmation dialog for "Deselect all files"** — the command now asks for confirmation before modifying files, preventing accidental bulk deselection
- **Improved performance in large vaults** — the status bar selection count no longer recalculates on every metadata change; rapid changes are batched together
- **Fixed a rare issue where rapid checkbox toggling in the bulk edit dialog could cause selection state to get out of sync**

## Summary

- Serialize `bulkSetSelection` writes through the `pendingSaves` map and add per-file cleanup so settled entries don't accumulate during a modal session
- Add a confirmation modal before the "Deselect all files" command, consistent with the existing confirmation on "Remove selection property"
- Debounce status bar updates from `metadataCache.on("changed")` and `vault.on("delete")` events (500ms) to collapse redundant full-vault scans during bulk operations

## Test plan

- [ ] Open bulk edit modal, rapidly toggle individual checkboxes then hit "Select all" — verify no console errors and selection state is consistent
- [ ] Toggle a few checkboxes rapidly then immediately click "Update" — verify the update completes without errors and all checked files are updated
- [ ] Run "Deselect all files" from command palette — verify confirmation dialog appears, cancel aborts, confirm proceeds
- [ ] Perform a bulk update on many files — verify status bar updates once after the operation settles, not per-file
- [ ] `npm run build` and `npm run lint` pass clean