### PR TITLE
Fix selection property not saving when chosen from suggestion dropdown

### DIFF
--- a/src/settings.ts
+++ b/src/settings.ts
@@ -145,27 +145,31 @@ export class BulkPropertiesSettingTab extends PluginSettingTab {
 			.setName("Selection property")
 			.setDesc("The checkbox property used to mark files as selected")
 			.addSearch(search => {
+				const saveSelectionProperty = async (value: string) => {
+					const normalized = value.trim() || "selected";
+					if (normalized === this.plugin.settings.selectionProperty) {
+						if (value.trim() === "") {
+							search.setValue(normalized);
+						}
+						return;
+					}
+					if (await this.updateSetting("selectionProperty", normalized)) {
+						// Only reset the input if the user hasn't typed
+						// something new while the save was in flight
+						if (search.inputEl.value === value) {
+							search.setValue(normalized);
+						}
+						this.plugin.updateStatusBar();
+					}
+				};
 				search
 					.setPlaceholder("Selected")
 					.setValue(this.plugin.settings.selectionProperty)
-					.onChange(async (value) => {
-						const normalized = value.trim() || "selected";
-						if (normalized === this.plugin.settings.selectionProperty) {
-							if (value.trim() === "") {
-								search.setValue(normalized);
-							}
-							return;
-						}
-						if (await this.updateSetting("selectionProperty", normalized)) {
-							// Only reset the input if the user hasn't typed
-							// something new while the save was in flight
-							if (search.inputEl.value === value) {
-								search.setValue(normalized);
-							}
-							this.plugin.updateStatusBar();
-						}
-					});
-				new PropertyNameSuggest(this.app, search.inputEl);
+					.onChange(saveSelectionProperty);
+				const suggest = new PropertyNameSuggest(this.app, search.inputEl);
+				suggest.onSuggestionSelected = () => {
+					void saveSelectionProperty(search.inputEl.value);
+				};
 			});
 
 		new Setting(containerEl)


### PR DESCRIPTION
## Summary

- Selecting a property name from the autocomplete dropdown in the "Selection property" setting updated the input visually but never persisted the change
- `AbstractInputSuggest.setValue()` sets `inputEl.value` directly without firing an `input` DOM event, so `SearchComponent.onChange()` never executes
- Wire up `onSuggestionSelected` on the selection property's `PropertyNameSuggest` to invoke the same save logic that `onChange` uses

## Test plan

- [ ] Start with `selectionProperty` set to `select` and a second checkbox property `selected` in the vault
- [ ] Open plugin settings, click `selected` in the suggestion dropdown
- [ ] Close and reopen settings — field should show `selected`
- [ ] Verify status bar count reflects the new property
- [ ] Confirm typing a property name manually still works