### PR TITLE
Block selection property from conflicting with configured properties

### DIFF
--- a/src/settings.ts
+++ b/src/settings.ts
@@ -176,8 +176,11 @@ export class BulkPropertiesSettingTab extends PluginSettingTab {
 						search.setValue(this.plugin.settings.selectionProperty);
 						return;
 					}
+					const draft = search.inputEl.value;
 					if (await this.updateSetting("selectionProperty", normalized)) {
-						search.setValue(normalized);
+						if (search.inputEl.value === draft) {
+							search.setValue(normalized);
+						}
 						this.plugin.updateStatusBar();
 						updateWarning();
 					}
@@ -201,9 +204,17 @@ export class BulkPropertiesSettingTab extends PluginSettingTab {
 					window.clearTimeout(pendingBlur);
 					void commitSelectionProperty();
 				};
-
-				updateWarning();
 			});
+
+		if (this.plugin.settings.properties.some(
+			p => p.name === this.plugin.settings.selectionProperty,
+		)) {
+			selectionSetting.descEl.createEl("br", {cls: "mod-warning"});
+			selectionSetting.descEl.createEl("span", {
+				text: `"${this.plugin.settings.selectionProperty}" is also a configured property and will be hidden in the bulk edit dialog`,
+				cls: "mod-warning",
+			});
+		}
 
 		new Setting(containerEl)
 			.setName("Deselect when finished")

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -141,16 +141,22 @@ export class BulkPropertiesSettingTab extends PluginSettingTab {
 		const {containerEl} = this;
 		containerEl.empty();
 
-		new Setting(containerEl)
+		const selectionSetting = new Setting(containerEl)
 			.setName("Selection property")
 			.setDesc("The checkbox property used to mark files as selected")
 			.addSearch(search => {
+				const isConflicting = (name: string) =>
+					this.plugin.settings.properties.some(p => p.name === name);
+
 				const saveSelectionProperty = async (value: string) => {
 					const normalized = value.trim() || "selected";
 					if (normalized === this.plugin.settings.selectionProperty) {
 						if (value.trim() === "") {
 							search.setValue(normalized);
 						}
+						return;
+					}
+					if (isConflicting(normalized)) {
 						return;
 					}
 					if (await this.updateSetting("selectionProperty", normalized)) {
@@ -162,15 +168,40 @@ export class BulkPropertiesSettingTab extends PluginSettingTab {
 						this.plugin.updateStatusBar();
 					}
 				};
+
+				const rejectIfConflicting = () => {
+					const value = search.inputEl.value.trim() || "selected";
+					if (isConflicting(value)) {
+						new Notice(
+							`"${value}" is already a configured property`,
+						);
+						search.setValue(this.plugin.settings.selectionProperty);
+					}
+				};
+
 				search
 					.setPlaceholder("Selected")
 					.setValue(this.plugin.settings.selectionProperty)
 					.onChange(saveSelectionProperty);
+				search.inputEl.addEventListener("blur", rejectIfConflicting);
 				const suggest = new PropertyNameSuggest(this.app, search.inputEl);
+				suggest.exclude = () =>
+					new Set(this.plugin.settings.properties.map(p => p.name));
 				suggest.onSuggestionSelected = () => {
-					void saveSelectionProperty(search.inputEl.value);
+					void saveSelectionProperty(search.inputEl.value)
+						.then(rejectIfConflicting);
 				};
 			});
+
+		if (this.plugin.settings.properties.some(
+			p => p.name === this.plugin.settings.selectionProperty,
+		)) {
+			selectionSetting.descEl.createEl("br");
+			selectionSetting.descEl.createEl("span", {
+				text: `"${this.plugin.settings.selectionProperty}" is also a configured property and will be hidden in the bulk edit dialog`,
+				cls: "mod-warning",
+			});
+		}
 
 		new Setting(containerEl)
 			.setName("Deselect when finished")

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -148,60 +148,62 @@ export class BulkPropertiesSettingTab extends PluginSettingTab {
 				const isConflicting = (name: string) =>
 					this.plugin.settings.properties.some(p => p.name === name);
 
-				const saveSelectionProperty = async (value: string) => {
-					const normalized = value.trim() || "selected";
+				const updateWarning = () => {
+					selectionSetting.descEl
+						.querySelectorAll(".mod-warning")
+						.forEach(el => el.remove());
+					if (isConflicting(this.plugin.settings.selectionProperty)) {
+						selectionSetting.descEl.createEl("br", {cls: "mod-warning"});
+						selectionSetting.descEl.createEl("span", {
+							text: `"${this.plugin.settings.selectionProperty}" is also a configured property and will be hidden in the bulk edit dialog`,
+							cls: "mod-warning",
+						});
+					}
+				};
+
+				const commitSelectionProperty = async () => {
+					const normalized = search.inputEl.value.trim() || "selected";
 					if (normalized === this.plugin.settings.selectionProperty) {
-						if (value.trim() === "") {
+						if (search.inputEl.value.trim() === "") {
 							search.setValue(normalized);
 						}
 						return;
 					}
 					if (isConflicting(normalized)) {
+						new Notice(
+							`"${normalized}" is already a configured property`,
+						);
+						search.setValue(this.plugin.settings.selectionProperty);
 						return;
 					}
 					if (await this.updateSetting("selectionProperty", normalized)) {
-						// Only reset the input if the user hasn't typed
-						// something new while the save was in flight
-						if (search.inputEl.value === value) {
-							search.setValue(normalized);
-						}
+						search.setValue(normalized);
 						this.plugin.updateStatusBar();
+						updateWarning();
 					}
 				};
 
-				const rejectIfConflicting = () => {
-					const value = search.inputEl.value.trim() || "selected";
-					if (isConflicting(value)) {
-						new Notice(
-							`"${value}" is already a configured property`,
-						);
-						search.setValue(this.plugin.settings.selectionProperty);
-					}
-				};
+				// Defer blur so a suggestion click can cancel it
+				let pendingBlur = 0;
 
 				search
 					.setPlaceholder("Selected")
-					.setValue(this.plugin.settings.selectionProperty)
-					.onChange(saveSelectionProperty);
-				search.inputEl.addEventListener("blur", rejectIfConflicting);
+					.setValue(this.plugin.settings.selectionProperty);
+				search.inputEl.addEventListener("blur", () => {
+					pendingBlur = window.setTimeout(
+						() => void commitSelectionProperty(), 0,
+					);
+				});
 				const suggest = new PropertyNameSuggest(this.app, search.inputEl);
 				suggest.exclude = () =>
 					new Set(this.plugin.settings.properties.map(p => p.name));
 				suggest.onSuggestionSelected = () => {
-					void saveSelectionProperty(search.inputEl.value)
-						.then(rejectIfConflicting);
+					window.clearTimeout(pendingBlur);
+					void commitSelectionProperty();
 				};
-			});
 
-		if (this.plugin.settings.properties.some(
-			p => p.name === this.plugin.settings.selectionProperty,
-		)) {
-			selectionSetting.descEl.createEl("br");
-			selectionSetting.descEl.createEl("span", {
-				text: `"${this.plugin.settings.selectionProperty}" is also a configured property and will be hidden in the bulk edit dialog`,
-				cls: "mod-warning",
+				updateWarning();
 			});
-		}
 
 		new Setting(containerEl)
 			.setName("Deselect when finished")


### PR DESCRIPTION
## Summary

- Prevent the selection property from being set to a value that already exists in the properties edit list
- Selection property field now saves on blur/suggestion-selection instead of every keystroke, avoiding false conflict notices while typing through a matching prefix
- Show a warning in settings when a pre-existing conflict is detected on disk

## Test plan

- [ ] Add property "foo" to the edit list, type "foo" in the selection property field and blur — notice appears, input reverts
- [ ] Type "foobar" through "foo" prefix and blur — no notice, field stays on "foobar"
- [ ] Confirm "foo" is excluded from the selection property suggestion dropdown
- [ ] Edit `data.json` to create a pre-existing conflict, reload plugin, open settings — warning appears on the selection property setting
- [ ] Fix the conflict by changing the selection property — warning disappears inline
- [ ] Change selection property to a valid name and blur — saves and persists across reload
- [ ] Clear the field and blur — defaults to "selected"
- [ ] Select a value from the suggestion dropdown — saves correctly, no double-fire
- [ ] Open bulk edit dialog — selection property does not appear in editable properties
- [ ] Confirm adding the selection property via "Add property" is still blocked