### PR TITLE
Fix type dropdown auto-selecting Text for unknown properties

### DIFF
--- a/src/settings.ts
+++ b/src/settings.ts
@@ -325,7 +325,6 @@ export class BulkPropertiesSettingTab extends PluginSettingTab {
 					value: "",
 					text: "Choose type\u2026",
 				});
-				placeholder.disabled = true;
 				placeholder.selected = true;
 
 				const sorted = Object.entries(PROPERTY_TYPE_LABELS)

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -73,6 +73,12 @@ const PROPERTY_TYPE_LABELS: Record<PropertyType, string> = {
 // doesn't match a recognized type.
 function detectPropertyType(app: App, name: string): PropertyType | null {
 	try {
+		// Only look up types for properties that exist in the vault.
+		// metadataTypeManager returns a default widget ("text") for unknown
+		// names, which would silently pre-fill the type dropdown.
+		const known = new Set(getAllPropertyNames(app));
+		if (!known.has(name)) return null;
+
 		// metadataTypeManager is an undocumented internal API — not in
 		// obsidian.d.ts. All access is runtime-guarded; the any cast and
 		// unsafe member accesses are intentional.


### PR DESCRIPTION
## Summary
- Remove `disabled` attribute from the type dropdown placeholder option so `setValue("")` can programmatically re-select it
- Guard `detectPropertyType` to only query `metadataTypeManager` for property names that actually exist in the vault — it returns `{widget: "text"}` as a default for unknown names, which silently pre-filled the dropdown

## Test plan
- [ ] Open settings, type a never-before-seen property name, press Tab — dropdown should stay on "Choose type…"
- [ ] Type a known vault property name, press Tab — dropdown should auto-detect the correct type
- [ ] Select a known property from the suggestion dropdown — type should auto-detect