### PR TITLE
Make file list rows clickable and fix keyboard focus

### DIFF
--- a/src/bulk-edit-modal.ts
+++ b/src/bulk-edit-modal.ts
@@ -154,7 +154,7 @@ export class BulkEditModal extends Modal {
 
 		const listEl = contentEl.createDiv({cls: "bulk-properties-file-list"});
 		for (const [file, checked] of this.fileSelection) {
-			const row = listEl.createDiv({cls: "bulk-properties-file-row"});
+			const row = listEl.createEl("label", {cls: "bulk-properties-file-row"});
 			const checkbox = row.createEl("input", {type: "checkbox"});
 			checkbox.type = "checkbox";
 			checkbox.checked = checked;

--- a/src/bulk-edit-modal.ts
+++ b/src/bulk-edit-modal.ts
@@ -279,6 +279,7 @@ export class BulkEditModal extends Modal {
 			this.updateCountText();
 			if (!this.uiLocked) {
 				checkbox.disabled = false;
+				checkbox.focus();
 			}
 		});
 		this.pendingSaves.set(file, save);

--- a/src/bulk-edit-modal.ts
+++ b/src/bulk-edit-modal.ts
@@ -279,7 +279,9 @@ export class BulkEditModal extends Modal {
 			this.updateCountText();
 			if (!this.uiLocked) {
 				checkbox.disabled = false;
-				checkbox.focus();
+				if (document.activeElement === document.body) {
+					checkbox.focus();
+				}
 			}
 		});
 		this.pendingSaves.set(file, save);


### PR DESCRIPTION
## Summary
- Use `<label>` instead of `<div>` for file rows in the bulk edit modal so clicking the file path text toggles the checkbox
- Restore keyboard focus to the checkbox after the async save re-enables it, so spacebar continues to work without needing to tab away and back
- Guard the refocus to only fire when the user hasn't already tabbed to another control

## Test plan
- [ ] Open bulk edit modal with selected files
- [ ] Click on a file path label — checkbox toggles
- [ ] Click directly on a checkbox — still works
- [ ] Tab to a checkbox, press spacebar repeatedly — toggles each time
- [ ] Toggle a checkbox, quickly tab to another control — focus stays on new control
- [ ] Select All / Deselect All still work