### PR TITLE
Link empty-state message to plugin settings

### DIFF
--- a/src/bulk-edit-modal.ts
+++ b/src/bulk-edit-modal.ts
@@ -191,8 +191,13 @@ export class BulkEditModal extends Modal {
 				this.close();
 				/* eslint-disable @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call -- undocumented Obsidian API */
 				const setting = (this.app as any).setting;
-				setting.open();
-				setting.openTabById(this.plugin.manifest.id);
+				if (typeof setting?.open === "function" && typeof setting?.openTabById === "function") {
+					setting.open();
+					setting.openTabById(this.plugin.manifest.id);
+				} else {
+					// eslint-disable-next-line obsidianmd/ui/sentence-case -- navigation path
+					new Notice("Open Settings → Community plugins → Bulk Properties to configure properties.");
+				}
 				/* eslint-enable @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call */
 			});
 			p.appendText(".");

--- a/src/bulk-edit-modal.ts
+++ b/src/bulk-edit-modal.ts
@@ -182,7 +182,20 @@ export class BulkEditModal extends Modal {
 		const editableProperties = settings.properties.filter(p => p.name !== settings.selectionProperty);
 
 		if (editableProperties.length === 0) {
-			contentEl.createEl("p", {text: "No properties configured. Add properties in the plugin settings."});
+			const p = contentEl.createEl("p");
+			p.appendText("No properties configured. Add properties in the ");
+			// eslint-disable-next-line obsidianmd/ui/sentence-case -- mid-sentence text
+			const link = p.createEl("a", {text: "plugin settings", href: "#"});
+			link.addEventListener("click", (e) => {
+				e.preventDefault();
+				this.close();
+				/* eslint-disable @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call -- undocumented Obsidian API */
+				const setting = (this.app as any).setting;
+				setting.open();
+				setting.openTabById(this.plugin.manifest.id);
+				/* eslint-enable @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call */
+			});
+			p.appendText(".");
 			return;
 		}
 

--- a/styles.css
+++ b/styles.css
@@ -12,6 +12,12 @@
 	font-size: var(--font-ui-medium);
 }
 
+.bulk-properties-modal a:focus-visible {
+	outline: 2px solid var(--background-modifier-border-focus);
+	outline-offset: 2px;
+	border-radius: var(--radius-s);
+}
+
 .bulk-properties-file-list {
 	max-height: 200px;
 	overflow-y: auto;


### PR DESCRIPTION
## Summary

- When the Bulk Edit Properties modal opens with no configured properties, "plugin settings" in the empty-state message is now a clickable link that closes the modal and opens the plugin's settings tab
- Uses feature detection on the undocumented `app.setting` API with a `Notice` fallback if the API is absent
- Adds a `:focus-visible` outline for keyboard accessibility on links in the modal

## Test plan

- [ ] Remove all configured properties from plugin settings
- [ ] Run "Bulk edit properties" command
- [ ] Verify "plugin settings" renders as a styled link
- [ ] Click the link — modal closes, plugin settings tab opens
- [ ] Tab to the link — focus outline is visible
- [ ] Press Enter on the focused link — same behavior as click