### PR TITLE
Warn when selection property is not a Checkbox type

### DIFF
--- a/src/settings.ts
+++ b/src/settings.ts
@@ -165,6 +165,14 @@ export class BulkPropertiesSettingTab extends PluginSettingTab {
 							cls: "mod-warning",
 						});
 					}
+					const type = detectPropertyType(this.app, this.plugin.settings.selectionProperty);
+					if (type !== null && type !== "checkbox") {
+						selectionSetting.descEl.createEl("br", {cls: "mod-warning"});
+						selectionSetting.descEl.createEl("span", {
+							text: `The selection property must be a Checkbox type; this property has the ${PROPERTY_TYPE_LABELS[type]} type`,
+							cls: "mod-warning",
+						});
+					}
 				};
 
 				const commitSelectionProperty = async () => {
@@ -218,6 +226,14 @@ export class BulkPropertiesSettingTab extends PluginSettingTab {
 			selectionSetting.descEl.createEl("br", {cls: "mod-warning"});
 			selectionSetting.descEl.createEl("span", {
 				text: `"${this.plugin.settings.selectionProperty}" is also a configured property and will be hidden in the bulk edit dialog`,
+				cls: "mod-warning",
+			});
+		}
+		const selectionType = detectPropertyType(this.app, this.plugin.settings.selectionProperty);
+		if (selectionType !== null && selectionType !== "checkbox") {
+			selectionSetting.descEl.createEl("br", {cls: "mod-warning"});
+			selectionSetting.descEl.createEl("span", {
+				text: `The selection property must be a Checkbox type; this property has the ${PROPERTY_TYPE_LABELS[selectionType]} type`,
 				cls: "mod-warning",
 			});
 		}


### PR DESCRIPTION
## Summary

- Show a warning in plugin settings when the selection property has a known non-checkbox type (e.g. Text, Number)
- Warning appears both on initial settings display and when the user changes the value
- No warning is shown if the property type cannot be determined (API unavailable, property not in vault, or unrecognized type)
- Uses the existing `detectPropertyType()` function and `PROPERTY_TYPE_LABELS` map — no new utilities

## Test plan

- [ ] Set selection property to a known Text property → warning appears: "The selection property must be a Checkbox type; this property has the Text type"
- [ ] Set it to a known Checkbox property → no type warning
- [ ] Set it to a property name that doesn't exist in the vault → no warning
- [ ] Change the value → warnings update dynamically
- [ ] Close and reopen settings with a non-checkbox selection property already persisted → warning appears on load