### PR TITLE
Parallelize bulk writes and add settle wait

### DIFF
--- a/src/bulk-edit-modal.ts
+++ b/src/bulk-edit-modal.ts
@@ -813,6 +813,7 @@ export class BulkEditModal extends Modal {
 				);
 				if (skipped) skippedCount++;
 			},
+			{app: this.app, awaitConsistency: "metadata"},
 		);
 
 		const actualSucceeded = result.succeeded - skippedCount;
@@ -856,6 +857,7 @@ export class BulkEditModal extends Modal {
 			filesToDelete,
 			"Deleting",
 			(file) => this.app.fileManager.trashFile(file),
+			{app: this.app, awaitConsistency: "vault-delete"},
 		);
 
 		const {succeeded, failed, cancelled, total} = result;

--- a/src/deselect-all.ts
+++ b/src/deselect-all.ts
@@ -28,6 +28,7 @@ export async function deselectAll(
 				},
 			);
 		},
+		{app, awaitConsistency: "metadata"},
 	);
 
 	const {succeeded, failed, cancelled, total} = result;

--- a/src/progress.ts
+++ b/src/progress.ts
@@ -1,4 +1,4 @@
-import {Notice, TFile} from "obsidian";
+import {App, EventRef, Notice, TFile} from "obsidian";
 
 export interface ProgressResult {
 	succeeded: number;
@@ -7,17 +7,64 @@ export interface ProgressResult {
 	total: number;
 }
 
+export type AwaitConsistency = "metadata" | "vault-delete" | "none";
+
+export interface WithProgressOptions {
+	/** Max in-flight actions. Default 8. */
+	concurrency?: number;
+	/** Best-effort post-write settle strategy. Default "none". */
+	awaitConsistency?: AwaitConsistency;
+	/** Quiet period after the last relevant event. Default 500 ms. */
+	quietWindowMs?: number;
+	/** Minimum post-write delay if no relevant event has been seen. Default 250 ms. */
+	minimumFallbackWaitMs?: number;
+	/** Hard ceiling on settle wait. Default 1500 ms. */
+	consistencyTimeoutMs?: number;
+	/** Label shown during settle wait. Default "Finishing up". */
+	indexingLabel?: string;
+	/** Obsidian app, required when awaitConsistency !== "none". */
+	app?: App;
+}
+
+const DEFAULT_CONCURRENCY = 8;
+const DEFAULT_QUIET_WINDOW_MS = 500;
+const DEFAULT_MIN_FALLBACK_WAIT_MS = 250;
+const DEFAULT_CONSISTENCY_TIMEOUT_MS = 1500;
+const DEFAULT_INDEXING_LABEL = "Finishing up";
+const SETTLE_POLL_INTERVAL_MS = 50;
+
 /**
- * Iterates files with a cancelable progress notice, calling `action`
- * on each. Returns counts of succeeded/failed and whether the user
- * cancelled.
+ * Iterates files with a cancelable progress notice, calling `action` on
+ * each. Writes run with bounded concurrency. Optionally pauses after the
+ * write phase to let Obsidian's metadata cache (or vault delete stream)
+ * settle, so the completion notice does not visibly precede the status bar
+ * catching up.
+ *
+ * Cancellation during the write phase stops claiming new work and awaits
+ * in-flight actions; cancellation during the settle phase resolves
+ * immediately and is treated as a successful completion.
  */
 export async function withProgress(
 	files: TFile[],
 	label: string,
 	action: (file: TFile) => Promise<void>,
+	options: WithProgressOptions = {},
 ): Promise<ProgressResult> {
-	let cancelled = false;
+	const concurrency = Math.max(1, options.concurrency ?? DEFAULT_CONCURRENCY);
+	const awaitConsistency = options.awaitConsistency ?? "none";
+	const quietWindowMs = options.quietWindowMs ?? DEFAULT_QUIET_WINDOW_MS;
+	const minimumFallbackWaitMs = options.minimumFallbackWaitMs ?? DEFAULT_MIN_FALLBACK_WAIT_MS;
+	const consistencyTimeoutMs = options.consistencyTimeoutMs ?? DEFAULT_CONSISTENCY_TIMEOUT_MS;
+	const indexingLabel = options.indexingLabel ?? DEFAULT_INDEXING_LABEL;
+	const app = options.app;
+
+	if (awaitConsistency !== "none" && !app) {
+		throw new Error(
+			"withProgress: `app` is required when `awaitConsistency` is enabled",
+		);
+	}
+
+	let cancelRequested = false;
 	const notice = new Notice("", 0);
 
 	const cancelBtn = notice.messageEl.createEl("button", {
@@ -25,7 +72,7 @@ export async function withProgress(
 		cls: "mod-warning bulk-properties-cancel-btn",
 	});
 	cancelBtn.addEventListener("click", () => {
-		cancelled = true;
+		cancelRequested = true;
 	});
 
 	const textEl = notice.messageEl.createSpan();
@@ -34,26 +81,93 @@ export async function withProgress(
 	let succeeded = 0;
 	const failed: string[] = [];
 
+	let eventSource: {offref(ref: EventRef): void} | null = null;
+	let eventRef: EventRef | null = null;
+	let lastRelevantEventAt = 0;
+	let anyRelevantEventSeen = false;
+
+	if (awaitConsistency !== "none" && app) {
+		const onEvent = () => {
+			lastRelevantEventAt = Date.now();
+			anyRelevantEventSeen = true;
+		};
+		if (awaitConsistency === "metadata") {
+			eventSource = app.metadataCache;
+			eventRef = app.metadataCache.on("changed", onEvent);
+		} else {
+			eventSource = app.vault;
+			eventRef = app.vault.on("delete", onEvent);
+		}
+	}
+
 	try {
-		for (let i = 0; i < files.length; i++) {
-			if (cancelled) break;
-			const file = files[i]!;
+		textEl.textContent = `${label} 0 / ${files.length}...`;
 
-			textEl.textContent = `${label} ${i + 1} / ${files.length}...`;
+		let nextIndex = 0;
+		let completedCount = 0;
+		const workerCount = Math.min(concurrency, files.length);
 
-			try {
-				await action(file);
-				succeeded++;
-			} catch (err: unknown) {
-				console.error(
-					`bulk-properties: ${label} failed on ${file.path}:`,
-					err,
+		const runWorker = async (): Promise<void> => {
+			while (!cancelRequested) {
+				const i = nextIndex++;
+				if (i >= files.length) return;
+				const file = files[i]!;
+				try {
+					await action(file);
+					succeeded++;
+				} catch (err: unknown) {
+					console.error(
+						`bulk-properties: ${label} failed on ${file.path}:`,
+						err,
+					);
+					failed.push(file.path);
+				}
+				completedCount++;
+				if (!cancelRequested) {
+					textEl.textContent = `${label} ${completedCount} / ${files.length}...`;
+				}
+			}
+		};
+
+		const workers: Promise<void>[] = [];
+		for (let w = 0; w < workerCount; w++) {
+			workers.push(runWorker());
+		}
+		await Promise.all(workers);
+
+		// Settle phase: writes done, let Obsidian catch up briefly before
+		// dropping the notice. Skipped if user cancelled mid-writes.
+		const writesFullyProcessed = completedCount === files.length;
+		if (writesFullyProcessed && awaitConsistency !== "none" && !cancelRequested) {
+			textEl.textContent = `${indexingLabel}...`;
+
+			const settleStartedAt = Date.now();
+			while (!cancelRequested) {
+				const now = Date.now();
+				const totalElapsed = now - settleStartedAt;
+
+				if (totalElapsed >= consistencyTimeoutMs) break;
+
+				if (anyRelevantEventSeen) {
+					if (now - lastRelevantEventAt >= quietWindowMs) break;
+				} else if (totalElapsed >= minimumFallbackWaitMs) {
+					break;
+				}
+
+				await new Promise(resolve =>
+					setTimeout(resolve, SETTLE_POLL_INTERVAL_MS),
 				);
-				failed.push(file.path);
 			}
 		}
+
+		// "Cancelled" only counts if the user stopped new work mid-writes,
+		// not if they clicked Cancel during the settle pause.
+		const cancelled = cancelRequested && !writesFullyProcessed;
+		return {succeeded, failed, cancelled, total: files.length};
 	} finally {
+		if (eventSource && eventRef) {
+			eventSource.offref(eventRef);
+		}
 		notice.hide();
 	}
-	return {succeeded, failed, cancelled, total: files.length};
 }

--- a/src/progress.ts
+++ b/src/progress.ts
@@ -16,7 +16,7 @@ export interface WithProgressOptions {
 	awaitConsistency?: AwaitConsistency;
 	/** Quiet period after the last relevant event. Default 500 ms. */
 	quietWindowMs?: number;
-	/** Minimum post-write delay if no relevant event has been seen. Default 250 ms. */
+	/** Minimum settle phase duration, regardless of event activity. Default 250 ms. */
 	minimumFallbackWaitMs?: number;
 	/** Hard ceiling on settle wait. Default 1500 ms. */
 	consistencyTimeoutMs?: number;
@@ -148,9 +148,11 @@ export async function withProgress(
 
 				if (totalElapsed >= consistencyTimeoutMs) break;
 
-				if (anyRelevantEventSeen) {
-					if (now - lastRelevantEventAt >= quietWindowMs) break;
-				} else if (totalElapsed >= minimumFallbackWaitMs) {
+				if (
+					totalElapsed >= minimumFallbackWaitMs
+					&& anyRelevantEventSeen
+					&& now - lastRelevantEventAt >= quietWindowMs
+				) {
 					break;
 				}
 

--- a/src/progress.ts
+++ b/src/progress.ts
@@ -84,12 +84,10 @@ export async function withProgress(
 	let eventSource: {offref(ref: EventRef): void} | null = null;
 	let eventRef: EventRef | null = null;
 	let lastRelevantEventAt = 0;
-	let anyRelevantEventSeen = false;
 
 	if (awaitConsistency !== "none" && app) {
 		const onEvent = () => {
 			lastRelevantEventAt = Date.now();
-			anyRelevantEventSeen = true;
 		};
 		if (awaitConsistency === "metadata") {
 			eventSource = app.metadataCache;
@@ -141,13 +139,6 @@ export async function withProgress(
 		if (writesFullyProcessed && awaitConsistency !== "none" && !cancelRequested) {
 			textEl.textContent = `${indexingLabel}...`;
 
-			// Events fired during writes can't count toward the settle-phase
-			// quiet window — on long batches they'd be stale before the last
-			// file's event has even arrived. Reset so the quiet window is
-			// measured purely over the settle phase.
-			lastRelevantEventAt = 0;
-			anyRelevantEventSeen = false;
-
 			const settleStartedAt = Date.now();
 			while (!cancelRequested) {
 				const now = Date.now();
@@ -155,10 +146,14 @@ export async function withProgress(
 
 				if (totalElapsed >= consistencyTimeoutMs) break;
 
+				// Pin events older than settleStartedAt to settleStartedAt so
+				// the quiet window measures post-settle activity. Events fired
+				// during the write phase don't shortcut the wait, but a
+				// completely quiet settle phase still exits after quietWindowMs.
+				const quietAnchor = Math.max(lastRelevantEventAt, settleStartedAt);
 				if (
 					totalElapsed >= minimumFallbackWaitMs
-					&& anyRelevantEventSeen
-					&& now - lastRelevantEventAt >= quietWindowMs
+					&& now - quietAnchor >= quietWindowMs
 				) {
 					break;
 				}

--- a/src/progress.ts
+++ b/src/progress.ts
@@ -141,6 +141,13 @@ export async function withProgress(
 		if (writesFullyProcessed && awaitConsistency !== "none" && !cancelRequested) {
 			textEl.textContent = `${indexingLabel}...`;
 
+			// Events fired during writes can't count toward the settle-phase
+			// quiet window — on long batches they'd be stale before the last
+			// file's event has even arrived. Reset so the quiet window is
+			// measured purely over the settle phase.
+			lastRelevantEventAt = 0;
+			anyRelevantEventSeen = false;
+
 			const settleStartedAt = Date.now();
 			while (!cancelRequested) {
 				const now = Date.now();

--- a/src/remove-selection-property.ts
+++ b/src/remove-selection-property.ts
@@ -102,6 +102,7 @@ async function doRemove(
 				},
 			);
 		},
+		{app, awaitConsistency: "metadata"},
 	);
 
 	const {succeeded, failed, cancelled, total} = result;


### PR DESCRIPTION
## Summary

- `withProgress` in `src/progress.ts` now runs actions through a bounded worker pool (default concurrency 8) instead of a strict sequential loop, making bulk operations on large selections meaningfully faster.
- Adds an optional post-write settle phase that briefly keeps the progress notice open while Obsidian's metadata cache (or vault delete stream) catches up, so the completion notice no longer appears visibly before the status bar count stops updating.
- `deselectAll`, `removeSelectionProperty`, and `BulkEditModal.doUpdate` opt into `awaitConsistency: "metadata"`; `BulkEditModal.doDelete` uses `awaitConsistency: "vault-delete"`.

## Behavior details

Settle phase exits on the earliest of:
1. `quietWindowMs` (500 ms) of quiet since the last relevant event, measured from settle start (pre-settle events are pinned to `settleStartedAt` so they don't shortcut the wait).
2. `minimumFallbackWaitMs` (250 ms) acts as a floor — the settle phase can't exit earlier even if no events arrive.
3. `consistencyTimeoutMs` (1500 ms) is the hard ceiling.

Cancellation during the write phase stops claiming new work and returns `cancelled: true`; cancellation during the settle phase resolves immediately and is treated as a successful completion.

## Test plan

All tests in the dev vault with a full Obsidian reload after the build. The commands under test are:

- **Command: Deselect all notes**
- **Command: Remove selection property from all notes**
- **Bulk edit modal → Update properties** (CTA button)
- **Bulk edit modal → Delete selected notes** (warning button)

### New behavior (performance and completion accuracy)

- [ ] With 800+ notes selected, run **Deselect all notes**. Expect materially faster completion than the previous release.
- [ ] When the completion notice appears, the status bar count should already read 0 or be empty — no visible trailing countdown.
- [ ] Brief (~1 s or less) lag between completion notice and final status bar state is acceptable and expected on a noisy vault.
- [ ] With 800+ notes having the selection property set, run **Remove selection property from all notes**. Same speed and accuracy checks.
- [ ] Select 200+ notes via the selection property, open **Bulk edit**, set a value on some property (e.g. a tags merge), and click **Update properties**. Confirm completion notice timing and status bar both match.
- [ ] Using scratch notes only, select 50+ notes, open **Bulk edit**, click **Delete selected notes**, confirm. The notice should not appear until those notes are actually gone from the file explorer.

### Cancel during the write phase

- [ ] Run **Deselect all notes** on 800+ notes, click the Cancel button while the progress counter is still advancing. Expect the notice to read `Deselected N of total notes (cancelled)` and for N to match what the status bar shows.
- [ ] Run **Remove selection property from all notes** and cancel mid-run. Same expectation.
- [ ] Bulk edit → **Update properties** on 200+ notes, cancel mid-run. Expect `Updated "prop" in N of total notes (cancelled)`.
- [ ] Bulk edit → **Delete selected notes** on 50+ scratch notes, cancel mid-run. Expect `Deleted N of total notes (cancelled)`.

### Cancel during the settle phase

- [ ] Run **Deselect all notes**, wait for the write counter to finish and the notice to switch to `Finishing up...`, then click Cancel. Expect the notice to dismiss immediately with the normal `Deselected N notes` message (not cancelled), and for the status bar to catch up within about a second.
- [ ] Same check on **Remove selection property from all notes**.

### Regression checks on touched code paths

- [ ] Open the **Bulk edit** modal with files selected. Toggle an individual row's checkbox on and off. Count text should update, the checkbox should remain interactive, and the underlying note's frontmatter should reflect the toggle.
- [ ] In the **Bulk edit** modal, click **Select all** and then **Deselect all**. Count text should go to total then 0; writes should apply to all files without errors in the dev console.
- [ ] Run **Update properties** with a non-array property (text, number, date, datetime, checkbox). Values should be written correctly and the existing "Deselect when finished" toggle should still unset the selection property when enabled.
- [ ] Run **Update properties** with a tags/aliases/multitext property using each of Merge, Replace, and Delete. Merge should dedupe, Replace should confirm before overwriting, Delete should remove only the specified values.
- [ ] Run **Update properties** on a mix of files where some frontmatter contains a non-list value for a list-type property. Those should still be reported as skipped in the completion notice.
- [ ] Run **Update properties** with the value field containing an uncommitted pill input. Expect the notice `Commit or clear the text in the input field before updating`.
- [ ] Run **Delete selected notes** with 1 scratch note selected. Expect the confirm dialog; after confirming, the single note should be trashed and the notice should read `Deleted 1 note`.
- [ ] Force a write failure (e.g. make a note read-only) and run **Deselect all notes**. Expect the completion notice to include `failed on 1: <path>`.
- [ ] Open **Bulk edit** with no files selected. Confirm the empty-state message still shows and no buttons are enabled.
- [ ] Run any bulk command while Obsidian's file explorer is visible. Confirm the explorer reflects changes (either property values in Properties view or removed files on delete) within about a second of the completion notice.

### Build and lint

- [ ] `npm run lint` clean
- [ ] `npm run build` clean