### PR TITLE
Parallelize withProgress actions with bounded worker pool

### DIFF
--- a/src/bulk-edit-modal.ts
+++ b/src/bulk-edit-modal.ts
@@ -856,6 +856,7 @@ export class BulkEditModal extends Modal {
 			filesToDelete,
 			"Deleting",
 			(file) => this.app.fileManager.trashFile(file),
+			1,
 		);
 
 		const {succeeded, failed, cancelled, total} = result;

--- a/src/progress.ts
+++ b/src/progress.ts
@@ -7,17 +7,19 @@ export interface ProgressResult {
 	total: number;
 }
 
-const CONCURRENCY = 8;
+const DEFAULT_CONCURRENCY = 8;
 
 /**
  * Iterates files with a cancelable progress notice, calling `action`
  * on each with bounded concurrency. Returns counts of succeeded/failed
- * and whether the user cancelled.
+ * and whether the user cancelled. Pass `concurrency: 1` for destructive
+ * actions where cancel should stop after at most one more file.
  */
 export async function withProgress(
 	files: TFile[],
 	label: string,
 	action: (file: TFile) => Promise<void>,
+	concurrency: number = DEFAULT_CONCURRENCY,
 ): Promise<ProgressResult> {
 	let cancelled = false;
 	const notice = new Notice("", 0);
@@ -41,7 +43,7 @@ export async function withProgress(
 	try {
 		textEl.textContent = `${label} 0 / ${files.length}...`;
 
-		const workerCount = Math.min(CONCURRENCY, files.length);
+		const workerCount = Math.min(concurrency, files.length);
 		const runWorker = async (): Promise<void> => {
 			while (!cancelled) {
 				const i = nextIndex++;

--- a/src/progress.ts
+++ b/src/progress.ts
@@ -7,10 +7,12 @@ export interface ProgressResult {
 	total: number;
 }
 
+const CONCURRENCY = 8;
+
 /**
  * Iterates files with a cancelable progress notice, calling `action`
- * on each. Returns counts of succeeded/failed and whether the user
- * cancelled.
+ * on each with bounded concurrency. Returns counts of succeeded/failed
+ * and whether the user cancelled.
  */
 export async function withProgress(
 	files: TFile[],
@@ -33,25 +35,40 @@ export async function withProgress(
 
 	let succeeded = 0;
 	const failed: string[] = [];
+	let nextIndex = 0;
+	let completedCount = 0;
 
 	try {
-		for (let i = 0; i < files.length; i++) {
-			if (cancelled) break;
-			const file = files[i]!;
+		textEl.textContent = `${label} 0 / ${files.length}...`;
 
-			textEl.textContent = `${label} ${i + 1} / ${files.length}...`;
-
-			try {
-				await action(file);
-				succeeded++;
-			} catch (err: unknown) {
-				console.error(
-					`bulk-properties: ${label} failed on ${file.path}:`,
-					err,
-				);
-				failed.push(file.path);
+		const workerCount = Math.min(CONCURRENCY, files.length);
+		const runWorker = async (): Promise<void> => {
+			while (!cancelled) {
+				const i = nextIndex++;
+				if (i >= files.length) return;
+				const file = files[i]!;
+				try {
+					await action(file);
+					succeeded++;
+				} catch (err: unknown) {
+					console.error(
+						`bulk-properties: ${label} failed on ${file.path}:`,
+						err,
+					);
+					failed.push(file.path);
+				}
+				completedCount++;
+				if (!cancelled) {
+					textEl.textContent = `${label} ${completedCount} / ${files.length}...`;
+				}
 			}
+		};
+
+		const workers: Promise<void>[] = [];
+		for (let w = 0; w < workerCount; w++) {
+			workers.push(runWorker());
 		}
+		await Promise.all(workers);
 	} finally {
 		notice.hide();
 	}


### PR DESCRIPTION
## Summary

- `withProgress` in `src/progress.ts` now runs its per-file action through a bounded worker pool (default concurrency 8) instead of a strict sequential loop, making bulk metadata operations meaningfully faster.
- `withProgress` accepts an optional `concurrency` argument. The delete path in `BulkEditModal.doDelete` passes `1` so cancellation remains prompt for the destructive case — clicking Cancel stops after at most one more file. All other callers use the default.
- Progress text updates on completion rather than claim, so the displayed count is monotonically increasing.

## Test plan

Manual testing in the dev vault after a full `npm run build` and Obsidian reload.

### Throughput

- [ ] Select a batch (dozens of notes) via the selection property. Run **Deselect all notes**. Completion should feel meaningfully faster than a single-stream sequential loop.
- [ ] Same check with **Remove selection property from all notes**.
- [ ] Open the **Bulk edit** modal on a batch, set a property value, click **Update properties**. Writes should fan out in parallel.

### Cancellation

- [ ] Run **Deselect all notes** on a moderate batch, click Cancel mid-run. Completion notice should read `Deselected N of total notes (cancelled)`.
- [ ] Run **Remove selection property from all notes**, cancel mid-run. Same expectation.
- [ ] Bulk edit → **Update properties** on a moderate batch, cancel mid-run. Expect `Updated "prop" in N of total notes (cancelled)`.
- [ ] Bulk edit → **Delete selected notes** on scratch notes, cancel mid-run. Because delete runs sequentially, at most one additional note should be trashed after clicking Cancel.

### Regression checks on touched paths

- [ ] Per-file checkbox toggling inside the **Bulk edit** modal still works (count updates, checkbox re-enables, underlying frontmatter updates).
- [ ] **Select all** / **Deselect all** buttons inside the **Bulk edit** modal still work.
- [ ] **Update properties** works across all property types (text, number, date, datetime, checkbox, tags/aliases/multitext with Merge / Replace / Delete).
- [ ] **Update properties** with a non-list value on a list-type property still reports as skipped.
- [ ] **Update properties** with an uncommitted pill input still shows the `Commit or clear the text in the input field before updating` notice.
- [ ] Forcing a write failure (e.g. read-only note) during **Deselect all notes** still produces a `failed on 1: <path>` notice.
- [ ] Empty-state bulk-edit modal still renders correctly with no files selected.

### Build

- [ ] `npm run lint` clean
- [ ] `npm run build` clean