### PR TITLE
Add metadata cache warning after large bulk operations

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ This plugin uses a checkbox property (default: `selected`) to track which notes 
 
 **Note:** The plugin operates on all notes in the vault that have the selection property checked, not just notes visible in a particular Base. Make sure to uncheck the selection property on notes you don't want to modify.
 
+**Scale:** This plugin is intended for use on relatively small sets of notes at a time. When an operation modifies more than 25 notes, Obsidian's metadata cache may take several minutes to re-index the changed frontmatter, during which Bases and other property-driven views can show stale information. The plugin displays a warning when this happens; you can suppress it via **Settings → Bulk Properties → Warn after large operations**.
+
 ## Setup
 
 Before using the command, configure the plugin in **Settings → Bulk Properties**:

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This plugin uses a checkbox property (default: `selected`) to track which notes 
 
 **Note:** The plugin operates on all notes in the vault that have the selection property checked, not just notes visible in a particular Base. Make sure to uncheck the selection property on notes you don't want to modify.
 
-**Scale:** This plugin is intended for use on relatively small sets of notes at a time. When an operation modifies more than 25 notes, Obsidian's metadata cache may take several minutes to re-index the changed frontmatter, during which Bases and other property-driven views can show stale information. The plugin displays a warning when this happens; you can suppress it via **Settings → Bulk Properties → Warn after large operations**.
+**Scale:** This plugin is intended for use on relatively small sets of notes at a time. When an operation modifies many notes, Obsidian's metadata cache may take several minutes to re-index the changed frontmatter, during which Bases and other property-driven views can show stale information. The plugin displays a warning when this happens; you can suppress it via **Settings → Bulk Properties → Warn after large operations**.
 
 ## Setup
 

--- a/src/bulk-edit-modal.ts
+++ b/src/bulk-edit-modal.ts
@@ -2,6 +2,10 @@ import {AbstractInputSuggest, App, Modal, Notice, setIcon, Setting, TFile} from 
 import type BulkPropertiesPlugin from "./main";
 import {getPropertyValues, getSelectedFiles} from "./files";
 import {confirmDeleteFiles, confirmEmptyValue, confirmReplace} from "./confirm-modal";
+import {
+	shouldWarnLargeOperation,
+	showLargeOperationNotice,
+} from "./large-operation-notice";
 import {withProgress} from "./progress";
 import {makeToggleAccessible, updateToggleAriaChecked} from "./accessible-toggle";
 
@@ -827,7 +831,11 @@ export class BulkEditModal extends Modal {
 		if (failed.length > 0) {
 			msg += `, failed on ${failed.length}: ${failed.join(", ")}`;
 		}
-		new Notice(msg);
+		if (shouldWarnLargeOperation(this.plugin, actualSucceeded)) {
+			showLargeOperationNotice(this.plugin, actualSucceeded, msg);
+		} else {
+			new Notice(msg);
+		}
 	}
 
 	private async doDelete() {
@@ -867,6 +875,10 @@ export class BulkEditModal extends Modal {
 		if (failed.length > 0) {
 			msg += `, failed on ${failed.length}: ${failed.join(", ")}`;
 		}
-		new Notice(msg);
+		if (shouldWarnLargeOperation(this.plugin, succeeded)) {
+			showLargeOperationNotice(this.plugin, succeeded, msg);
+		} else {
+			new Notice(msg);
+		}
 	}
 }

--- a/src/bulk-edit-modal.ts
+++ b/src/bulk-edit-modal.ts
@@ -875,10 +875,6 @@ export class BulkEditModal extends Modal {
 		if (failed.length > 0) {
 			msg += `, failed on ${failed.length}: ${failed.join(", ")}`;
 		}
-		if (shouldWarnLargeOperation(this.plugin, succeeded)) {
-			showLargeOperationNotice(this.plugin, succeeded, msg);
-		} else {
-			new Notice(msg);
-		}
+		new Notice(msg);
 	}
 }

--- a/src/deselect-all.ts
+++ b/src/deselect-all.ts
@@ -1,12 +1,18 @@
-import {App, Notice} from "obsidian";
+import {Notice} from "obsidian";
+import type BulkPropertiesPlugin from "./main";
 import {confirmDeselectAll} from "./confirm-modal";
 import {getSelectedFiles} from "./files";
+import {
+	shouldWarnLargeOperation,
+	showLargeOperationNotice,
+} from "./large-operation-notice";
 import {withProgress} from "./progress";
 
 export async function deselectAll(
-	app: App,
-	selectionProperty: string,
+	plugin: BulkPropertiesPlugin,
 ): Promise<void> {
+	const {app} = plugin;
+	const selectionProperty = plugin.settings.selectionProperty;
 	const files = getSelectedFiles(app, selectionProperty);
 
 	if (files.length === 0) {
@@ -31,17 +37,18 @@ export async function deselectAll(
 	);
 
 	const {succeeded, failed, cancelled, total} = result;
+	let msg: string;
 	if (cancelled) {
-		new Notice(
-			`Deselected ${succeeded} of ${total} note${total === 1 ? "" : "s"} (cancelled)`,
-		);
+		msg = `Deselected ${succeeded} of ${total} note${total === 1 ? "" : "s"} (cancelled)`;
 	} else if (failed.length === 0) {
-		new Notice(
-			`Deselected ${succeeded} note${succeeded === 1 ? "" : "s"}`,
-		);
+		msg = `Deselected ${succeeded} note${succeeded === 1 ? "" : "s"}`;
 	} else {
-		new Notice(
-			`Deselected ${succeeded} note${succeeded === 1 ? "" : "s"}, failed on ${failed.length}: ${failed.join(", ")}`,
-		);
+		msg = `Deselected ${succeeded} note${succeeded === 1 ? "" : "s"}, failed on ${failed.length}: ${failed.join(", ")}`;
+	}
+
+	if (shouldWarnLargeOperation(plugin, succeeded)) {
+		showLargeOperationNotice(plugin, succeeded, msg);
+	} else {
+		new Notice(msg);
 	}
 }

--- a/src/large-operation-notice.ts
+++ b/src/large-operation-notice.ts
@@ -2,7 +2,7 @@ import {Modal, Notice, Setting} from "obsidian";
 import type BulkPropertiesPlugin from "./main";
 import {makeToggleAccessible, updateToggleAriaChecked} from "./accessible-toggle";
 
-export const LARGE_OPERATION_THRESHOLD = 75;
+export const LARGE_OPERATION_THRESHOLD = 25;
 
 export function shouldWarnLargeOperation(
 	plugin: BulkPropertiesPlugin,

--- a/src/large-operation-notice.ts
+++ b/src/large-operation-notice.ts
@@ -1,0 +1,92 @@
+import {Modal, Notice, Setting} from "obsidian";
+import type BulkPropertiesPlugin from "./main";
+import {makeToggleAccessible, updateToggleAriaChecked} from "./accessible-toggle";
+
+export const LARGE_OPERATION_THRESHOLD = 75;
+
+export function shouldWarnLargeOperation(
+	plugin: BulkPropertiesPlugin,
+	count: number,
+): boolean {
+	return count > LARGE_OPERATION_THRESHOLD
+		&& plugin.settings.showLargeOperationWarning;
+}
+
+class LargeOperationNoticeModal extends Modal {
+	private dontShowAgain = false;
+	private readonly summary: string;
+	private readonly count: number;
+	private readonly onSuppress: () => void;
+
+	constructor(
+		plugin: BulkPropertiesPlugin,
+		count: number,
+		summary: string,
+		onSuppress: () => void,
+	) {
+		super(plugin.app);
+		this.summary = summary;
+		this.count = count;
+		this.onSuppress = onSuppress;
+	}
+
+	override onOpen() {
+		const {contentEl} = this;
+
+		new Setting(contentEl)
+			.setName("Obsidian is updating its metadata cache")
+			.setHeading();
+
+		contentEl.createEl("p", {text: this.summary});
+
+		contentEl.createEl("p", {
+			text: `You modified ${this.count} notes. Obsidian will re-index its metadata cache in the background, which may take several minutes depending on your vault size and device speed. Until it finishes, Bases and the selection count in the status bar may be out of date.`,
+		});
+
+		new Setting(contentEl)
+			.setName("Don't show this again")
+			.setDesc("You can re-enable this warning in settings.")
+			.addToggle(toggle => {
+				makeToggleAccessible(toggle, "Don't show this again", false);
+				toggle
+					.setValue(false)
+					.onChange(value => {
+						updateToggleAriaChecked(toggle, value);
+						this.dontShowAgain = value;
+					});
+			});
+
+		new Setting(contentEl)
+			.addButton(btn => btn
+				.setButtonText("Close")
+				.setCta()
+				.onClick(() => this.close()));
+	}
+
+	override onClose() {
+		if (this.dontShowAgain) {
+			this.onSuppress();
+		}
+		this.contentEl.empty();
+	}
+}
+
+export function showLargeOperationNotice(
+	plugin: BulkPropertiesPlugin,
+	count: number,
+	summary: string,
+): void {
+	const onSuppress = () => {
+		plugin.updateSetting("showLargeOperationWarning", false)
+			.catch((err: unknown) => {
+				console.error(
+					"bulk-properties: failed to save showLargeOperationWarning:",
+					err,
+				);
+				new Notice(
+					"Failed to save preference. The large-operation warning may appear again.",
+				);
+			});
+	};
+	new LargeOperationNoticeModal(plugin, count, summary, onSuppress).open();
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -33,7 +33,7 @@ export default class BulkPropertiesPlugin extends Plugin {
 			id: "deselect-all",
 			name: "Deselect all notes",
 			callback: () => {
-				void deselectAll(this.app, this.settings.selectionProperty);
+				void deselectAll(this);
 			},
 		});
 
@@ -41,10 +41,7 @@ export default class BulkPropertiesPlugin extends Plugin {
 			id: "remove-selection-property",
 			name: "Remove selection property from all notes",
 			callback: () => {
-				removeSelectionProperty(
-					this.app,
-					this.settings.selectionProperty,
-				);
+				removeSelectionProperty(this);
 			},
 		});
 
@@ -145,6 +142,11 @@ export default class BulkPropertiesPlugin extends Plugin {
 		if (typeof this.settings.selectionProperty !== "string"
 			|| this.settings.selectionProperty.trim() === "") {
 			this.settings.selectionProperty = DEFAULT_SETTINGS.selectionProperty;
+		}
+
+		if (typeof this.settings.showLargeOperationWarning !== "boolean") {
+			this.settings.showLargeOperationWarning =
+				DEFAULT_SETTINGS.showLargeOperationWarning;
 		}
 
 		if (!Array.isArray(this.settings.properties)) {

--- a/src/remove-selection-property.ts
+++ b/src/remove-selection-property.ts
@@ -78,7 +78,7 @@ export function removeSelectionProperty(
 	}
 
 	new ConfirmRemoveModal(app, selectionProperty, files.length, () => {
-		void doRemove(plugin, files).catch(
+		void doRemove(plugin, selectionProperty, files).catch(
 			(err: unknown) => {
 				console.error(
 					"bulk-properties: unexpected error during property removal:",
@@ -94,10 +94,10 @@ export function removeSelectionProperty(
 
 async function doRemove(
 	plugin: BulkPropertiesPlugin,
+	selectionProperty: string,
 	files: ReturnType<typeof getFilesWithProperty>,
 ): Promise<void> {
 	const {app} = plugin;
-	const selectionProperty = plugin.settings.selectionProperty;
 	const result = await withProgress(
 		files,
 		`Removing "${selectionProperty}"`,

--- a/src/remove-selection-property.ts
+++ b/src/remove-selection-property.ts
@@ -1,5 +1,10 @@
 import {App, Modal, Notice, Setting} from "obsidian";
+import type BulkPropertiesPlugin from "./main";
 import {getFilesWithProperty} from "./files";
+import {
+	shouldWarnLargeOperation,
+	showLargeOperationNotice,
+} from "./large-operation-notice";
 import {withProgress} from "./progress";
 
 class ConfirmRemoveModal extends Modal {
@@ -59,9 +64,10 @@ class ConfirmRemoveModal extends Modal {
  * a cancelable progress notice.
  */
 export function removeSelectionProperty(
-	app: App,
-	selectionProperty: string,
+	plugin: BulkPropertiesPlugin,
 ): void {
+	const {app} = plugin;
+	const selectionProperty = plugin.settings.selectionProperty;
 	const files = getFilesWithProperty(app, selectionProperty);
 
 	if (files.length === 0) {
@@ -72,7 +78,7 @@ export function removeSelectionProperty(
 	}
 
 	new ConfirmRemoveModal(app, selectionProperty, files.length, () => {
-		void doRemove(app, selectionProperty, files).catch(
+		void doRemove(plugin, files).catch(
 			(err: unknown) => {
 				console.error(
 					"bulk-properties: unexpected error during property removal:",
@@ -87,10 +93,11 @@ export function removeSelectionProperty(
 }
 
 async function doRemove(
-	app: App,
-	selectionProperty: string,
+	plugin: BulkPropertiesPlugin,
 	files: ReturnType<typeof getFilesWithProperty>,
 ): Promise<void> {
+	const {app} = plugin;
+	const selectionProperty = plugin.settings.selectionProperty;
 	const result = await withProgress(
 		files,
 		`Removing "${selectionProperty}"`,
@@ -105,17 +112,18 @@ async function doRemove(
 	);
 
 	const {succeeded, failed, cancelled, total} = result;
+	let msg: string;
 	if (cancelled) {
-		new Notice(
-			`Removed "${selectionProperty}" from ${succeeded} of ${total} note${total === 1 ? "" : "s"} (cancelled)`,
-		);
+		msg = `Removed "${selectionProperty}" from ${succeeded} of ${total} note${total === 1 ? "" : "s"} (cancelled)`;
 	} else if (failed.length === 0) {
-		new Notice(
-			`Removed "${selectionProperty}" from ${succeeded} note${succeeded === 1 ? "" : "s"}`,
-		);
+		msg = `Removed "${selectionProperty}" from ${succeeded} note${succeeded === 1 ? "" : "s"}`;
 	} else {
-		new Notice(
-			`Removed from ${succeeded} note${succeeded === 1 ? "" : "s"}, failed on ${failed.length}: ${failed.join(", ")}`,
-		);
+		msg = `Removed from ${succeeded} note${succeeded === 1 ? "" : "s"}, failed on ${failed.length}: ${failed.join(", ")}`;
+	}
+
+	if (shouldWarnLargeOperation(plugin, succeeded)) {
+		showLargeOperationNotice(plugin, succeeded, msg);
+	} else {
+		new Notice(msg);
 	}
 }

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -107,6 +107,7 @@ export interface BulkPropertiesSettings {
 	properties: PropertyConfig[];
 	lastSelectedProperty: string;
 	showStatusBarCount: boolean;
+	showLargeOperationWarning: boolean;
 }
 
 export const DEFAULT_SETTINGS: BulkPropertiesSettings = {
@@ -115,6 +116,7 @@ export const DEFAULT_SETTINGS: BulkPropertiesSettings = {
 	properties: [],
 	lastSelectedProperty: "",
 	showStatusBarCount: true,
+	showLargeOperationWarning: true,
 };
 
 export class BulkPropertiesSettingTab extends PluginSettingTab {
@@ -263,6 +265,19 @@ export class BulkPropertiesSettingTab extends PluginSettingTab {
 						if (await this.updateSetting("showStatusBarCount", value)) {
 							this.plugin.updateStatusBar();
 						}
+					});
+			});
+
+		new Setting(containerEl)
+			.setName("Warn after large operations")
+			.setDesc("Re-enable the metadata cache warning after dismissing it. Shown after operations that modify many notes.")
+			.addToggle(toggle => {
+				makeToggleAccessible(toggle, "Warn after large operations", this.plugin.settings.showLargeOperationWarning);
+				toggle
+					.setValue(this.plugin.settings.showLargeOperationWarning)
+					.onChange(async (value) => {
+						updateToggleAriaChecked(toggle, value);
+						await this.updateSetting("showLargeOperationWarning", value);
 					});
 			});
 


### PR DESCRIPTION
## Summary

- After bulk operations that modify more than 25 notes, show a modal warning that Obsidian's metadata cache may take several minutes to re-index, and that Bases and the status bar selection count may be out of date until it finishes
- The modal includes a "Don't show this again" toggle, persisted via a new `showLargeOperationWarning` setting and re-enableable from the settings tab
- File deletion is excluded from the warning because cache reconciliation for deletions is fast (entry removal vs frontmatter re-parse)
- Simplifies `deselectAll` and `removeSelectionProperty` signatures to take the plugin instance directly
- Documents scale expectations in the README

## Test plan

- [ ] Small operation (<= 25 notes): transient Notice appears, no modal
- [ ] Large operation (> 25 notes) via bulk update: modal appears with summary and cache warning, no Notice
- [ ] Large operation via deselect all: same modal behavior
- [ ] Large operation via remove selection property: same modal behavior
- [ ] Bulk delete (any count): Notice only, no modal
- [ ] "Don't show this again" toggle + Close: subsequent large ops show Notice instead of modal
- [ ] "Don't show this again" toggle + Escape: same suppression behavior
- [ ] Settings → Warn after large operations toggle re-enables the modal
- [ ] Fresh install (no data.json): warning defaults to enabled
- [ ] `npm run lint` and `npm run build` clean