### PR TITLE
Show ribbon icon inline in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Before using the command, configure the plugin in **Settings → Bulk Properties
 
 1. Add the selection property to your notes or Base view.
 2. Check the box on each note you want to bulk edit.
-3. Open the bulk edit dialog from the ribbon icon, the **Bulk edit selected notes** command, or the editor right-click menu.
+3. Open the bulk edit dialog from the ribbon icon (<picture><source media="(prefers-color-scheme: dark)" srcset="docs/ribbon-icon-dark.svg"><img src="docs/ribbon-icon-light.svg" width="16" height="16" alt="list-checks icon"></picture>), the **Bulk edit selected notes** command, or the editor right-click menu.
 4. Review the note checklist — uncheck any notes you don't want to modify, or re-check notes you do.
 5. Choose a property from the dropdown, enter the new value, and select **Update properties**. For multi-value properties (Aliases, List, Tags), choose an action: **Merge** adds new values to existing ones, **Replace** overwrites the current values, and **Delete** removes matching values.
 6. To delete the checked notes instead, select **Delete selected notes**. After a confirmation prompt, the notes are deleted following your **Settings → Files and links → Deleted files** preference — they may be moved to the system trash, moved to an Obsidian `.trash` folder, or permanently deleted, depending on how that preference is configured.

--- a/docs/ribbon-icon-dark.svg
+++ b/docs/ribbon-icon-dark.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="#e6edf3" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <path d="M13 5h8" />
+  <path d="M13 12h8" />
+  <path d="M13 19h8" />
+  <path d="m3 17 2 2 4-4" />
+  <path d="m3 7 2 2 4-4" />
+</svg>

--- a/docs/ribbon-icon-light.svg
+++ b/docs/ribbon-icon-light.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="#1f2328" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <path d="M13 5h8" />
+  <path d="M13 12h8" />
+  <path d="M13 19h8" />
+  <path d="m3 17 2 2 4-4" />
+  <path d="m3 7 2 2 4-4" />
+</svg>


### PR DESCRIPTION
## Summary
- Add the Lucide `list-checks` ribbon icon inline in the Usage section after the word "icon"
- Include light and dark theme SVG variants so the icon adapts to the reader's GitHub theme via `<picture>`

## Test plan
- [ ] Verify the icon renders inline on the GitHub README in light mode
- [ ] Verify the icon renders inline on the GitHub README in dark mode