### PR TITLE
Address Obsidian review lint findings

### DIFF
--- a/eslint.config.mts
+++ b/eslint.config.mts
@@ -18,7 +18,6 @@ export default tseslint.config(
 			parserOptions: {
 				projectService: {
 					allowDefaultProject: [
-						'eslint.config.js',
 						'manifest.json'
 					]
 				},
@@ -43,7 +42,7 @@ export default tseslint.config(
 		"node_modules",
 		"dist",
 		"esbuild.config.mjs",
-		"eslint.config.js",
+		"eslint.config.mts",
 		"version-bump.mjs",
 		"versions.json",
 		"main.js",

--- a/eslint.config.mts
+++ b/eslint.config.mts
@@ -5,6 +5,12 @@ import { globalIgnores } from "eslint/config";
 
 export default tseslint.config(
 	{
+		// Report directive comments that silence rules which never fired.
+		// Obsidian's plugin reviewer enables this; without it, stale
+		// eslint-disable comments slip through local lint.
+		linterOptions: {
+			reportUnusedDisableDirectives: "error",
+		},
 		languageOptions: {
 			globals: {
 				...globals.browser,
@@ -22,6 +28,17 @@ export default tseslint.config(
 		},
 	},
 	...obsidianmd.configs.recommended,
+	{
+		// The obsidianmd preset disables require-await, but Obsidian's
+		// reviewer enforces it. Re-enable so local lint matches.
+		files: ['**/*.ts', '**/*.tsx'],
+		plugins: {
+			'@typescript-eslint': tseslint.plugin,
+		},
+		rules: {
+			"@typescript-eslint/require-await": "error",
+		},
+	},
 	globalIgnores([
 		"node_modules",
 		"dist",

--- a/src/bulk-edit-modal.ts
+++ b/src/bulk-edit-modal.ts
@@ -9,6 +9,17 @@ import {
 import {withProgress} from "./progress";
 import {makeToggleAccessible, updateToggleAriaChecked} from "./accessible-toggle";
 
+// `app.setting` is an undocumented internal API used by core plugins to
+// open the settings pane. Declared here as an optional property so it
+// can be accessed type-safely without reaching for `any`; all usages
+// are runtime-guarded.
+type AppWithSetting = App & {
+	setting?: {
+		open?: () => void;
+		openTabById?: (id: string) => void;
+	};
+};
+
 /**
  * Validates a tag name against Obsidian's naming rules.
  * Returns null if valid, or a reason string if invalid.
@@ -167,7 +178,7 @@ export class BulkEditModal extends Modal {
 			this.fileCheckboxes.set(file, checkbox);
 			row.createEl("span", {text: file.path, cls: "bulk-properties-file-path"});
 			checkbox.addEventListener("change", () => {
-				void this.toggleSelection(file, checkbox);
+				this.toggleSelection(file, checkbox);
 			});
 		}
 
@@ -190,22 +201,18 @@ export class BulkEditModal extends Modal {
 
 		if (!hasEditableProperties) {
 			const p = contentEl.createEl("p");
-			p.appendText("No properties configured. Add properties in the ");
-			// eslint-disable-next-line obsidianmd/ui/sentence-case -- mid-sentence text
-			const link = p.createEl("a", {text: "plugin settings", href: "#"});
+			p.appendText("No properties configured. ");
+			const link = p.createEl("a", {text: "Open settings to configure properties", href: "#"});
 			link.addEventListener("click", (e) => {
 				e.preventDefault();
 				this.close();
-				/* eslint-disable @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call -- undocumented Obsidian API */
-				const setting = (this.app as any).setting;
+				const {setting} = this.app as AppWithSetting;
 				if (typeof setting?.open === "function" && typeof setting?.openTabById === "function") {
 					setting.open();
 					setting.openTabById(this.plugin.manifest.id);
 				} else {
-					// eslint-disable-next-line obsidianmd/ui/sentence-case -- navigation path
-					new Notice("Open Settings → Community plugins → Bulk Properties to configure properties.");
+					new Notice("Open the settings pane to configure properties.");
 				}
-				/* eslint-enable @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call */
 			});
 			p.appendText(".");
 		}
@@ -301,7 +308,7 @@ export class BulkEditModal extends Modal {
 		this.fileSelection.set(file, selected);
 	}
 
-	private async toggleSelection(file: TFile, checkbox: HTMLInputElement) {
+	private toggleSelection(file: TFile, checkbox: HTMLInputElement): void {
 		const desired = checkbox.checked;
 		checkbox.disabled = true;
 

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -67,6 +67,16 @@ const PROPERTY_TYPE_LABELS: Record<PropertyType, string> = {
 	text: "Text",
 };
 
+// metadataTypeManager is an undocumented internal API — not in
+// obsidian.d.ts. Declared here as an optional property of App so all
+// access is type-safe without reaching for `any`. All access is also
+// runtime-guarded below.
+type AppWithMetadataTypeManager = App & {
+	metadataTypeManager?: {
+		getPropertyInfo?: (name: string) => { widget?: string } | undefined;
+	};
+};
+
 // Uses Obsidian's undocumented metadataTypeManager to look up the type
 // assigned to a property in Settings → Properties. Returns null if the
 // API is unavailable, the property is unknown, or the widget value
@@ -79,13 +89,7 @@ function detectPropertyType(app: App, name: string): PropertyType | null {
 		const known = new Set(getAllPropertyNames(app));
 		if (!known.has(name)) return null;
 
-		// metadataTypeManager is an undocumented internal API — not in
-		// obsidian.d.ts. All access is runtime-guarded; the any cast and
-		// unsafe member accesses are intentional.
-		// eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-member-access
-		const mtm = (app as any).metadataTypeManager as
-			| { getPropertyInfo?: (name: string) => { widget?: string } | undefined }
-			| undefined;
+		const mtm = (app as AppWithMetadataTypeManager).metadataTypeManager;
 		if (!mtm || typeof mtm.getPropertyInfo !== "function") return null;
 		const info = mtm.getPropertyInfo(name);
 		if (!info || typeof info.widget !== "string") return null;


### PR DESCRIPTION
## Summary

Fixes the lint issues flagged by Obsidian's plugin reviewer and tightens local ESLint config so similar issues are caught locally going forward.

**Source fixes:**
- Replaced `(app as any).setting` and `(app as any).metadataTypeManager` with typed `App` intersection types (`AppWithSetting`, `AppWithMetadataTypeManager`), removing the `any` casts and the block of `no-unsafe-*` disables.
- Rephrased the empty-state link and its fallback `Notice` so they're valid sentence case without needing to disable `obsidianmd/ui/sentence-case`.
- Dropped `async` from `toggleSelection` — it built a promise chain in `.then()` but never awaited anything at its top level, so `@typescript-eslint/require-await` flagged it.

**ESLint config hardening:**
- Enabled `linterOptions.reportUnusedDisableDirectives: "error"` so stale `eslint-disable` comments fail lint locally.
- Re-enabled `@typescript-eslint/require-await` (the obsidianmd preset disables it, but Obsidian's reviewer enforces it).
- Removed stale `eslint.config.js` references from `allowDefaultProject` and `globalIgnores` (holdover from before the rename to `.mts`) and explicitly ignored `eslint.config.mts` to match how other build config files are handled.

## Test plan

- [x] `npm run lint` passes clean
- [x] `npm run build` passes (tsc + esbuild production)
- [x] Canary-tested `require-await` fires on an async-without-await function
- [x] Canary-tested `reportUnusedDisableDirectives` fires on a stale `eslint-disable`
- [x] Verified `eslint eslint.config.mts` now reports "File ignored because of a matching ignore pattern"
- [ ] Manual: open bulk edit modal with no properties configured, click the empty-state link, confirm settings pane opens to the plugin
- [ ] Manual: toggle several file checkboxes rapidly, confirm serialization still works (non-async `toggleSelection`)
- [ ] Manual: add a property in settings, confirm the type dropdown still pre-fills from `metadataTypeManager`