### PR TITLE
Add spacing below new value region in bulk edit modal

### DIFF
--- a/src/bulk-edit-modal.ts
+++ b/src/bulk-edit-modal.ts
@@ -235,7 +235,7 @@ export class BulkEditModal extends Modal {
 					});
 				});
 
-			this.valueContainerEl = contentEl.createDiv();
+			this.valueContainerEl = contentEl.createDiv({cls: "bulk-properties-value-container"});
 			this.renderValueInput();
 
 			new Setting(contentEl)

--- a/styles.css
+++ b/styles.css
@@ -43,6 +43,10 @@
 	margin-left: var(--size-4-2);
 }
 
+.bulk-properties-value-container {
+	padding-bottom: var(--size-4-3);
+}
+
 .bulk-properties-pill-container {
 	display: flex;
 	flex-wrap: wrap;


### PR DESCRIPTION
## Summary
- Adds `bulk-properties-value-container` class with `padding-bottom: var(--size-4-3)` so the New value / Values to add region has breathing room above the next setting's divider line.

## Test plan
- [ ] Open the bulk edit modal with a text property selected and verify spacing below the "New value" input
- [ ] Verify spacing also looks right for array types (tags/aliases/multitext) with pills