### PR TITLE
Move delete button to the select/deselect row

### DIFF
--- a/src/bulk-edit-modal.ts
+++ b/src/bulk-edit-modal.ts
@@ -182,7 +182,7 @@ export class BulkEditModal extends Modal {
 			});
 		}
 
-		new Setting(contentEl)
+		const selectionRow = new Setting(contentEl)
 			.addButton(btn => {
 				btn.setButtonText("Delete selected").onClick(() => {
 					void this.doDelete();
@@ -202,6 +202,7 @@ export class BulkEditModal extends Modal {
 				});
 				this.deselectAllBtn = btn.buttonEl;
 			});
+		selectionRow.settingEl.addClass("bulk-properties-selection-row");
 
 		const editableProperties = settings.properties.filter(p => p.name !== settings.selectionProperty);
 		const hasEditableProperties = editableProperties.length > 0;

--- a/src/bulk-edit-modal.ts
+++ b/src/bulk-edit-modal.ts
@@ -184,6 +184,13 @@ export class BulkEditModal extends Modal {
 
 		new Setting(contentEl)
 			.addButton(btn => {
+				btn.setButtonText("Delete selected").onClick(() => {
+					void this.doDelete();
+				});
+				this.deleteBtn = btn.buttonEl;
+				this.deleteBtn.addClass("bulk-properties-delete-btn");
+			})
+			.addButton(btn => {
 				btn.setButtonText("Select all").onClick(() => {
 					void this.bulkSetSelection(true);
 				});
@@ -249,20 +256,8 @@ export class BulkEditModal extends Modal {
 							updateToggleAriaChecked(toggle, value);
 						});
 				});
-		}
 
-		const footer = new Setting(contentEl)
-			.addButton(btn => {
-				btn
-					.setButtonText("Delete selected notes")
-					.setWarning()
-					.onClick(() => {
-						void this.doDelete();
-					});
-				this.deleteBtn = btn.buttonEl;
-			});
-		if (hasEditableProperties) {
-			footer.addButton(btn => {
+			new Setting(contentEl).addButton(btn => {
 				btn
 					.setButtonText("Update properties")
 					.setCta()

--- a/styles.css
+++ b/styles.css
@@ -43,6 +43,10 @@
 	margin-left: var(--size-4-2);
 }
 
+.bulk-properties-delete-btn {
+	margin-right: auto;
+}
+
 .bulk-properties-value-container {
 	padding-bottom: var(--size-4-3);
 }

--- a/styles.css
+++ b/styles.css
@@ -43,6 +43,10 @@
 	margin-left: var(--size-4-2);
 }
 
+.bulk-properties-selection-row .setting-item-info {
+	display: none;
+}
+
 .bulk-properties-delete-btn {
 	margin-right: auto;
 }


### PR DESCRIPTION
## Summary
- Move the "Delete selected notes" button out of the footer and into the Select all / Deselect all row, relabeled "Delete selected".
- Drop the warning-red styling so the button matches Select all / Deselect all; Update properties remains the CTA.
- Hide the empty `.setting-item-info` on this row so the control area spans the modal, letting `margin-right: auto` anchor Delete at the left edge while Select all / Deselect all stay right-aligned.

Closes #48.

## Test plan
- [ ] Open "Bulk edit selected notes" with notes checked: Delete selected sits at the far left of the select/deselect row; Select all / Deselect all are right-aligned.
- [ ] Click Delete selected and confirm the delete dialog and behavior are unchanged.
- [ ] Open the modal with no configured editable properties: the selection row (including Delete selected) still renders, and no Update properties button is shown.
- [ ] Deselect all notes: both Delete selected and Update properties become disabled.