### PR TITLE
Address Obsidian plugin review feedback

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
 				"@eslint/js": "9.39.4",
 				"@types/node": "^25.5.0",
 				"esbuild": "0.27.5",
-				"eslint-plugin-obsidianmd": "0.2.4",
+				"eslint-plugin-obsidianmd": "0.3.0",
 				"jiti": "2.6.1",
 				"obsidian": "1.12.3",
 				"tslib": "2.8.1",
@@ -768,44 +768,6 @@
 				"ret": "~0.1.10"
 			}
 		},
-		"node_modules/@nodelib/fs.scandir": {
-			"version": "2.1.5",
-			"resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
-			"integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@nodelib/fs.stat": "2.0.5",
-				"run-parallel": "^1.1.9"
-			},
-			"engines": {
-				"node": ">= 8"
-			}
-		},
-		"node_modules/@nodelib/fs.stat": {
-			"version": "2.0.5",
-			"resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
-			"integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">= 8"
-			}
-		},
-		"node_modules/@nodelib/fs.walk": {
-			"version": "1.2.8",
-			"resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
-			"integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@nodelib/fs.scandir": "2.1.5",
-				"fastq": "^1.6.0"
-			},
-			"engines": {
-				"node": ">= 8"
-			}
-		},
 		"node_modules/@pkgr/core": {
 			"version": "0.1.2",
 			"resolved": "https://registry.npmjs.org/@pkgr/core/-/core-0.1.2.tgz",
@@ -1455,19 +1417,6 @@
 			"dependencies": {
 				"balanced-match": "^1.0.0",
 				"concat-map": "0.0.1"
-			}
-		},
-		"node_modules/braces": {
-			"version": "3.0.3",
-			"resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
-			"integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"fill-range": "^7.1.1"
-			},
-			"engines": {
-				"node": ">=8"
 			}
 		},
 		"node_modules/call-bind": {
@@ -2394,20 +2343,21 @@
 			}
 		},
 		"node_modules/eslint-plugin-obsidianmd": {
-			"version": "0.2.4",
-			"resolved": "https://registry.npmjs.org/eslint-plugin-obsidianmd/-/eslint-plugin-obsidianmd-0.2.4.tgz",
-			"integrity": "sha512-5iO3WJ2ZWN4AqBLslS83KsdcEYbT6SiDgRkB9nfM/pM4N87BHBTmScANcSOMiSHDnN1h/vUvWw2scJslVddPVQ==",
+			"version": "0.3.0",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-obsidianmd/-/eslint-plugin-obsidianmd-0.3.0.tgz",
+			"integrity": "sha512-QvGDI6B2nxJBrsZKGTg31da2A/fEJNlnwN+fRZkaoPIu1QL3fYXUdpP7ThyMdr/0iTYQxifb9lt2X9cpydQx1w==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
+				"@eslint/config-helpers": "^0.4.2",
 				"@eslint/js": "^9.30.1",
 				"@eslint/json": "0.14.0",
 				"@microsoft/eslint-plugin-sdl": "^1.1.0",
 				"@types/eslint": "9.6.1",
 				"@types/node": "20.12.12",
-				"@typescript-eslint/types": "8.33.1",
-				"@typescript-eslint/utils": "8.33.1",
-				"eslint": ">=9.0.0 <10.0.0",
+				"@typescript-eslint/types": "^8.33.1",
+				"@typescript-eslint/utils": "^8.33.1",
+				"eslint": ">=9.0.0",
 				"eslint-plugin-depend": "1.3.1",
 				"eslint-plugin-import": "^2.31.0",
 				"eslint-plugin-json-schema-validator": "5.1.0",
@@ -2428,7 +2378,7 @@
 			"peerDependencies": {
 				"@eslint/js": "^9.30.1",
 				"@eslint/json": "0.14.0",
-				"eslint": ">=9.0.0 <10.0.0",
+				"eslint": ">=9.0.0",
 				"obsidian": "1.8.7",
 				"typescript-eslint": "^8.35.1"
 			}
@@ -2441,63 +2391,6 @@
 			"license": "MIT",
 			"dependencies": {
 				"undici-types": "~5.26.4"
-			}
-		},
-		"node_modules/eslint-plugin-obsidianmd/node_modules/@typescript-eslint/project-service": {
-			"version": "8.33.1",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.33.1.tgz",
-			"integrity": "sha512-DZR0efeNklDIHHGRpMpR5gJITQpu6tLr9lDJnKdONTC7vvzOlLAG/wcfxcdxEWrbiZApcoBCzXqU/Z458Za5Iw==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@typescript-eslint/tsconfig-utils": "^8.33.1",
-				"@typescript-eslint/types": "^8.33.1",
-				"debug": "^4.3.4"
-			},
-			"engines": {
-				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/typescript-eslint"
-			},
-			"peerDependencies": {
-				"typescript": ">=4.8.4 <5.9.0"
-			}
-		},
-		"node_modules/eslint-plugin-obsidianmd/node_modules/@typescript-eslint/scope-manager": {
-			"version": "8.33.1",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.33.1.tgz",
-			"integrity": "sha512-dM4UBtgmzHR9bS0Rv09JST0RcHYearoEoo3pG5B6GoTR9XcyeqX87FEhPo+5kTvVfKCvfHaHrcgeJQc6mrDKrA==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@typescript-eslint/types": "8.33.1",
-				"@typescript-eslint/visitor-keys": "8.33.1"
-			},
-			"engines": {
-				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/typescript-eslint"
-			}
-		},
-		"node_modules/eslint-plugin-obsidianmd/node_modules/@typescript-eslint/tsconfig-utils": {
-			"version": "8.33.1",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.33.1.tgz",
-			"integrity": "sha512-STAQsGYbHCF0/e+ShUQ4EatXQ7ceh3fBCXkNU7/MZVKulrlq1usH7t2FhxvCpuCi5O5oi1vmVaAjrGeL71OK1g==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/typescript-eslint"
-			},
-			"peerDependencies": {
-				"typescript": ">=4.8.4 <5.9.0"
 			}
 		},
 		"node_modules/eslint-plugin-obsidianmd/node_modules/@typescript-eslint/types": {
@@ -2514,87 +2407,6 @@
 				"url": "https://opencollective.com/typescript-eslint"
 			}
 		},
-		"node_modules/eslint-plugin-obsidianmd/node_modules/@typescript-eslint/typescript-estree": {
-			"version": "8.33.1",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.33.1.tgz",
-			"integrity": "sha512-+s9LYcT8LWjdYWu7IWs7FvUxpQ/DGkdjZeE/GGulHvv8rvYwQvVaUZ6DE+j5x/prADUgSbbCWZ2nPI3usuVeOA==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@typescript-eslint/project-service": "8.33.1",
-				"@typescript-eslint/tsconfig-utils": "8.33.1",
-				"@typescript-eslint/types": "8.33.1",
-				"@typescript-eslint/visitor-keys": "8.33.1",
-				"debug": "^4.3.4",
-				"fast-glob": "^3.3.2",
-				"is-glob": "^4.0.3",
-				"minimatch": "^9.0.4",
-				"semver": "^7.6.0",
-				"ts-api-utils": "^2.1.0"
-			},
-			"engines": {
-				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/typescript-eslint"
-			},
-			"peerDependencies": {
-				"typescript": ">=4.8.4 <5.9.0"
-			}
-		},
-		"node_modules/eslint-plugin-obsidianmd/node_modules/@typescript-eslint/utils": {
-			"version": "8.33.1",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.33.1.tgz",
-			"integrity": "sha512-52HaBiEQUaRYqAXpfzWSR2U3gxk92Kw006+xZpElaPMg3C4PgM+A5LqwoQI1f9E5aZ/qlxAZxzm42WX+vn92SQ==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@eslint-community/eslint-utils": "^4.7.0",
-				"@typescript-eslint/scope-manager": "8.33.1",
-				"@typescript-eslint/types": "8.33.1",
-				"@typescript-eslint/typescript-estree": "8.33.1"
-			},
-			"engines": {
-				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/typescript-eslint"
-			},
-			"peerDependencies": {
-				"eslint": "^8.57.0 || ^9.0.0",
-				"typescript": ">=4.8.4 <5.9.0"
-			}
-		},
-		"node_modules/eslint-plugin-obsidianmd/node_modules/@typescript-eslint/visitor-keys": {
-			"version": "8.33.1",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.33.1.tgz",
-			"integrity": "sha512-3i8NrFcZeeDHJ+7ZUuDkGT+UHq+XoFGsymNK2jZCOHcfEzRQ0BdpRtdpSx/Iyf3MHLWIcLS0COuOPibKQboIiQ==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@typescript-eslint/types": "8.33.1",
-				"eslint-visitor-keys": "^4.2.0"
-			},
-			"engines": {
-				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/typescript-eslint"
-			}
-		},
-		"node_modules/eslint-plugin-obsidianmd/node_modules/brace-expansion": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
-			"integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"balanced-match": "^1.0.0"
-			}
-		},
 		"node_modules/eslint-plugin-obsidianmd/node_modules/globals": {
 			"version": "14.0.0",
 			"resolved": "https://registry.npmjs.org/globals/-/globals-14.0.0.tgz",
@@ -2606,22 +2418,6 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/eslint-plugin-obsidianmd/node_modules/minimatch": {
-			"version": "9.0.9",
-			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
-			"integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
-			"dev": true,
-			"license": "ISC",
-			"dependencies": {
-				"brace-expansion": "^2.0.2"
-			},
-			"engines": {
-				"node": ">=16 || 14 >=14.17"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/isaacs"
 			}
 		},
 		"node_modules/eslint-plugin-obsidianmd/node_modules/semver": {
@@ -2826,36 +2622,6 @@
 			"dev": true,
 			"license": "MIT"
 		},
-		"node_modules/fast-glob": {
-			"version": "3.3.3",
-			"resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.3.tgz",
-			"integrity": "sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@nodelib/fs.stat": "^2.0.2",
-				"@nodelib/fs.walk": "^1.2.3",
-				"glob-parent": "^5.1.2",
-				"merge2": "^1.3.0",
-				"micromatch": "^4.0.8"
-			},
-			"engines": {
-				"node": ">=8.6.0"
-			}
-		},
-		"node_modules/fast-glob/node_modules/glob-parent": {
-			"version": "5.1.2",
-			"resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
-			"integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
-			"dev": true,
-			"license": "ISC",
-			"dependencies": {
-				"is-glob": "^4.0.1"
-			},
-			"engines": {
-				"node": ">= 6"
-			}
-		},
 		"node_modules/fast-json-stable-stringify": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
@@ -2871,9 +2637,9 @@
 			"license": "MIT"
 		},
 		"node_modules/fast-uri": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
-			"integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+			"version": "3.1.2",
+			"resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
+			"integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
 			"dev": true,
 			"funding": [
 				{
@@ -2886,16 +2652,6 @@
 				}
 			],
 			"license": "BSD-3-Clause"
-		},
-		"node_modules/fastq": {
-			"version": "1.20.1",
-			"resolved": "https://registry.npmjs.org/fastq/-/fastq-1.20.1.tgz",
-			"integrity": "sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==",
-			"dev": true,
-			"license": "ISC",
-			"dependencies": {
-				"reusify": "^1.0.4"
-			}
 		},
 		"node_modules/fdir": {
 			"version": "6.5.0",
@@ -2926,19 +2682,6 @@
 			},
 			"engines": {
 				"node": ">=16.0.0"
-			}
-		},
-		"node_modules/fill-range": {
-			"version": "7.1.1",
-			"resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
-			"integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"to-regex-range": "^5.0.1"
-			},
-			"engines": {
-				"node": ">=8"
 			}
 		},
 		"node_modules/find-up": {
@@ -3532,16 +3275,6 @@
 				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
-		"node_modules/is-number": {
-			"version": "7.0.0",
-			"resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
-			"integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=0.12.0"
-			}
-		},
 		"node_modules/is-number-object": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/is-number-object/-/is-number-object-1.1.1.tgz",
@@ -3983,43 +3716,6 @@
 				"node": ">= 0.4"
 			}
 		},
-		"node_modules/merge2": {
-			"version": "1.4.1",
-			"resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
-			"integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">= 8"
-			}
-		},
-		"node_modules/micromatch": {
-			"version": "4.0.8",
-			"resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
-			"integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"braces": "^3.0.3",
-				"picomatch": "^2.3.1"
-			},
-			"engines": {
-				"node": ">=8.6"
-			}
-		},
-		"node_modules/micromatch/node_modules/picomatch": {
-			"version": "2.3.2",
-			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
-			"integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=8.6"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/jonschlinkert"
-			}
-		},
 		"node_modules/minimatch": {
 			"version": "3.1.5",
 			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
@@ -4375,27 +4071,6 @@
 				"node": ">=6"
 			}
 		},
-		"node_modules/queue-microtask": {
-			"version": "1.2.3",
-			"resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
-			"integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
-			"dev": true,
-			"funding": [
-				{
-					"type": "github",
-					"url": "https://github.com/sponsors/feross"
-				},
-				{
-					"type": "patreon",
-					"url": "https://www.patreon.com/feross"
-				},
-				{
-					"type": "consulting",
-					"url": "https://feross.org/support"
-				}
-			],
-			"license": "MIT"
-		},
 		"node_modules/react-is": {
 			"version": "16.13.1",
 			"resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
@@ -4516,41 +4191,6 @@
 			"license": "MIT",
 			"engines": {
 				"node": ">=0.12"
-			}
-		},
-		"node_modules/reusify": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/reusify/-/reusify-1.1.0.tgz",
-			"integrity": "sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"iojs": ">=1.0.0",
-				"node": ">=0.10.0"
-			}
-		},
-		"node_modules/run-parallel": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
-			"integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
-			"dev": true,
-			"funding": [
-				{
-					"type": "github",
-					"url": "https://github.com/sponsors/feross"
-				},
-				{
-					"type": "patreon",
-					"url": "https://www.patreon.com/feross"
-				},
-				{
-					"type": "consulting",
-					"url": "https://feross.org/support"
-				}
-			],
-			"license": "MIT",
-			"dependencies": {
-				"queue-microtask": "^1.2.2"
 			}
 		},
 		"node_modules/safe-array-concat": {
@@ -5012,19 +4652,6 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/SuperchupuDev"
-			}
-		},
-		"node_modules/to-regex-range": {
-			"version": "5.0.1",
-			"resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
-			"integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"is-number": "^7.0.0"
-			},
-			"engines": {
-				"node": ">=8.0"
 			}
 		},
 		"node_modules/toml-eslint-parser": {

--- a/package.json
+++ b/package.json
@@ -13,14 +13,14 @@
 	"keywords": [],
 	"license": "MIT",
 	"devDependencies": {
+		"@eslint/js": "9.39.4",
 		"@types/node": "^25.5.0",
 		"esbuild": "0.27.5",
-		"eslint-plugin-obsidianmd": "0.2.4",
+		"eslint-plugin-obsidianmd": "0.3.0",
+		"jiti": "2.6.1",
 		"obsidian": "1.12.3",
 		"tslib": "2.8.1",
 		"typescript": "5.8.3",
-		"typescript-eslint": "8.58.0",
-		"@eslint/js": "9.39.4",
-		"jiti": "2.6.1"
+		"typescript-eslint": "8.58.0"
 	}
 }

--- a/src/bulk-edit-modal.ts
+++ b/src/bulk-edit-modal.ts
@@ -657,7 +657,7 @@ export class BulkEditModal extends Modal {
 						}
 					};
 					if (suggest) {
-						requestAnimationFrame(commitPending);
+						window.requestAnimationFrame(commitPending);
 					} else {
 						commitPending();
 					}

--- a/src/bulk-edit-modal.ts
+++ b/src/bulk-edit-modal.ts
@@ -176,7 +176,7 @@ export class BulkEditModal extends Modal {
 			checkbox.type = "checkbox";
 			checkbox.checked = checked;
 			this.fileCheckboxes.set(file, checkbox);
-			row.createEl("span", {text: file.path, cls: "bulk-properties-file-path"});
+			row.createSpan({text: file.path, cls: "bulk-properties-file-path"});
 			checkbox.addEventListener("change", () => {
 				this.toggleSelection(file, checkbox);
 			});

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -231,7 +231,7 @@ export class BulkPropertiesSettingTab extends PluginSettingTab {
 			p => p.name === this.plugin.settings.selectionProperty,
 		)) {
 			selectionSetting.descEl.createEl("br", {cls: "mod-warning"});
-			selectionSetting.descEl.createEl("span", {
+			selectionSetting.descEl.createSpan({
 				text: `"${this.plugin.settings.selectionProperty}" is also a configured property and will be hidden in the bulk edit dialog`,
 				cls: "mod-warning",
 			});

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -166,7 +166,7 @@ export class BulkPropertiesSettingTab extends PluginSettingTab {
 						.forEach(el => el.remove());
 					if (isConflicting(this.plugin.settings.selectionProperty)) {
 						selectionSetting.descEl.createEl("br", {cls: "mod-warning"});
-						selectionSetting.descEl.createEl("span", {
+						selectionSetting.descEl.createSpan({
 							text: `"${this.plugin.settings.selectionProperty}" is also a configured property and will be hidden in the bulk edit dialog`,
 							cls: "mod-warning",
 						});

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -174,7 +174,7 @@ export class BulkPropertiesSettingTab extends PluginSettingTab {
 					const type = detectPropertyType(this.app, this.plugin.settings.selectionProperty);
 					if (type !== null && type !== "checkbox") {
 						selectionSetting.descEl.createEl("br", {cls: "mod-warning"});
-						selectionSetting.descEl.createEl("span", {
+						selectionSetting.descEl.createSpan({
 							text: `The selection property must be a Checkbox type; this property has the ${PROPERTY_TYPE_LABELS[type]} type`,
 							cls: "mod-warning",
 						});

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -239,7 +239,7 @@ export class BulkPropertiesSettingTab extends PluginSettingTab {
 		const selectionType = detectPropertyType(this.app, this.plugin.settings.selectionProperty);
 		if (selectionType !== null && selectionType !== "checkbox") {
 			selectionSetting.descEl.createEl("br", {cls: "mod-warning"});
-			selectionSetting.descEl.createEl("span", {
+			selectionSetting.descEl.createSpan({
 				text: `The selection property must be a Checkbox type; this property has the ${PROPERTY_TYPE_LABELS[selectionType]} type`,
 				cls: "mod-warning",
 			});


### PR DESCRIPTION
## Summary
- Replace `createEl("span", ...)` calls with `createSpan(...)` across `bulk-edit-modal.ts` and `settings.ts` (5 sites) per Obsidian plugin review.
- Upgrade `eslint-plugin-obsidianmd` from 0.2.4 to 0.3.0; apply `prefer-window-timers` fix (`requestAnimationFrame` → `window.requestAnimationFrame`) for popout window compatibility.

## Test plan
- [x] `npm run lint` clean
- [x] `npm run build` clean
- [x] `npm audit` reports 0 vulnerabilities
- [ ] Manual smoke test of bulk edit modal and settings warnings in Obsidian