### PR TITLE
Attest release artifacts with build provenance

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,6 +10,8 @@ jobs:
         runs-on: ubuntu-latest
         permissions:
             contents: write
+            id-token: write
+            attestations: write
         steps:
             - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
               with:
@@ -33,6 +35,13 @@ jobs:
               run: |
                   npm ci
                   npm run build
+
+            - name: Attest release artifacts
+              uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4.1.0
+              with:
+                  subject-path: |
+                      main.js
+                      styles.css
 
             - name: Create release
               env:


### PR DESCRIPTION
## Summary
- Adds `actions/attest-build-provenance` step to the release workflow so `main.js` and `styles.css` are signed via Sigstore and verifiable with `gh attestation verify`.
- Grants the release job `id-token: write` and `attestations: write` for OIDC token minting and attestation recording.
- Addresses Obsidian plugin review feedback that release assets lacked GitHub artifact attestation.

## Test plan
- [ ] Push a release tag (e.g. `1.0.9`) and confirm the workflow run shows an "Attest release artifacts" step that succeeds.
- [ ] Verify the attestation appears under repo Actions → Attestations.
- [ ] Run `gh attestation verify main.js -R gtritchie/bulk-properties` and `gh attestation verify styles.css -R gtritchie/bulk-properties` against the published assets.