### PR TITLE
Update npm dependencies to latest

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,14 +10,14 @@
 			"license": "MIT",
 			"devDependencies": {
 				"@eslint/js": "9.39.4",
-				"@types/node": "^25.5.0",
-				"esbuild": "0.27.5",
+				"@types/node": "^25.9.1",
+				"esbuild": "0.28.0",
 				"eslint-plugin-obsidianmd": "0.3.0",
-				"jiti": "2.6.1",
-				"obsidian": "1.12.3",
+				"jiti": "2.7.0",
+				"obsidian": "1.13.0",
 				"tslib": "2.8.1",
-				"typescript": "5.8.3",
-				"typescript-eslint": "8.58.0"
+				"typescript": "6.0.3",
+				"typescript-eslint": "8.60.0"
 			}
 		},
 		"node_modules/@codemirror/state": {
@@ -46,9 +46,9 @@
 			}
 		},
 		"node_modules/@esbuild/aix-ppc64": {
-			"version": "0.27.5",
-			"resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.5.tgz",
-			"integrity": "sha512-nGsF/4C7uzUj+Nj/4J+Zt0bYQ6bz33Phz8Lb2N80Mti1HjGclTJdXZ+9APC4kLvONbjxN1zfvYNd8FEcbBK/MQ==",
+			"version": "0.28.0",
+			"resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.0.tgz",
+			"integrity": "sha512-lhRUCeuOyJQURhTxl4WkpFTjIsbDayJHih5kZC1giwE+MhIzAb7mEsQMqMf18rHLsrb5qI1tafG20mLxEWcWlA==",
 			"cpu": [
 				"ppc64"
 			],
@@ -63,9 +63,9 @@
 			}
 		},
 		"node_modules/@esbuild/android-arm": {
-			"version": "0.27.5",
-			"resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.5.tgz",
-			"integrity": "sha512-Cv781jd0Rfj/paoNrul1/r4G0HLvuFKYh7C9uHZ2Pl8YXstzvCyyeWENTFR9qFnRzNMCjXmsulZuvosDg10Mog==",
+			"version": "0.28.0",
+			"resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.0.tgz",
+			"integrity": "sha512-wqh0ByljabXLKHeWXYLqoJ5jKC4XBaw6Hk08OfMrCRd2nP2ZQ5eleDZC41XHyCNgktBGYMbqnrJKq/K/lzPMSQ==",
 			"cpu": [
 				"arm"
 			],
@@ -80,9 +80,9 @@
 			}
 		},
 		"node_modules/@esbuild/android-arm64": {
-			"version": "0.27.5",
-			"resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.5.tgz",
-			"integrity": "sha512-Oeghq+XFgh1pUGd1YKs4DDoxzxkoUkvko+T/IVKwlghKLvvjbGFB3ek8VEDBmNvqhwuL0CQS3cExdzpmUyIrgA==",
+			"version": "0.28.0",
+			"resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.0.tgz",
+			"integrity": "sha512-+WzIXQOSaGs33tLEgYPYe/yQHf0WTU0X42Jca3y8NWMbUVhp7rUnw+vAsRC/QiDrdD31IszMrZy+qwPOPjd+rw==",
 			"cpu": [
 				"arm64"
 			],
@@ -97,9 +97,9 @@
 			}
 		},
 		"node_modules/@esbuild/android-x64": {
-			"version": "0.27.5",
-			"resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.5.tgz",
-			"integrity": "sha512-nQD7lspbzerlmtNOxYMFAGmhxgzn8Z7m9jgFkh6kpkjsAhZee1w8tJW3ZlW+N9iRePz0oPUDrYrXidCPSImD0Q==",
+			"version": "0.28.0",
+			"resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.0.tgz",
+			"integrity": "sha512-+VJggoaKhk2VNNqVL7f6S189UzShHC/mR9EE8rDdSkdpN0KflSwWY/gWjDrNxxisg8Fp1ZCD9jLMo4m0OUfeUA==",
 			"cpu": [
 				"x64"
 			],
@@ -114,9 +114,9 @@
 			}
 		},
 		"node_modules/@esbuild/darwin-arm64": {
-			"version": "0.27.5",
-			"resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.5.tgz",
-			"integrity": "sha512-I+Ya/MgC6rr8oRWGRDF3BXDfP8K1BVUggHqN6VI2lUZLdDi1IM1v2cy0e3lCPbP+pVcK3Tv8cgUhHse1kaNZZw==",
+			"version": "0.28.0",
+			"resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.0.tgz",
+			"integrity": "sha512-0T+A9WZm+bZ84nZBtk1ckYsOvyA3x7e2Acj1KdVfV4/2tdG4fzUp91YHx+GArWLtwqp77pBXVCPn2We7Letr0Q==",
 			"cpu": [
 				"arm64"
 			],
@@ -131,9 +131,9 @@
 			}
 		},
 		"node_modules/@esbuild/darwin-x64": {
-			"version": "0.27.5",
-			"resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.5.tgz",
-			"integrity": "sha512-MCjQUtC8wWJn/pIPM7vQaO69BFgwPD1jriEdqwTCKzWjGgkMbcg+M5HzrOhPhuYe1AJjXlHmD142KQf+jnYj8A==",
+			"version": "0.28.0",
+			"resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.0.tgz",
+			"integrity": "sha512-fyzLm/DLDl/84OCfp2f/XQ4flmORsjU7VKt8HLjvIXChJoFFOIL6pLJPH4Yhd1n1gGFF9mPwtlN5Wf82DZs+LQ==",
 			"cpu": [
 				"x64"
 			],
@@ -148,9 +148,9 @@
 			}
 		},
 		"node_modules/@esbuild/freebsd-arm64": {
-			"version": "0.27.5",
-			"resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.5.tgz",
-			"integrity": "sha512-X6xVS+goSH0UelYXnuf4GHLwpOdc8rgK/zai+dKzBMnncw7BTQIwquOodE7EKvY2UVUetSqyAfyZC1D+oqLQtg==",
+			"version": "0.28.0",
+			"resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.0.tgz",
+			"integrity": "sha512-l9GeW5UZBT9k9brBYI+0WDffcRxgHQD8ShN2Ur4xWq/NFzUKm3k5lsH4PdaRgb2w7mI9u61nr2gI2mLI27Nh3Q==",
 			"cpu": [
 				"arm64"
 			],
@@ -165,9 +165,9 @@
 			}
 		},
 		"node_modules/@esbuild/freebsd-x64": {
-			"version": "0.27.5",
-			"resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.5.tgz",
-			"integrity": "sha512-233X1FGo3a8x1ekLB6XT69LfZ83vqz+9z3TSEQCTYfMNY880A97nr81KbPcAMl9rmOFp11wO0dP+eB18KU/Ucg==",
+			"version": "0.28.0",
+			"resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.0.tgz",
+			"integrity": "sha512-BXoQai/A0wPO6Es3yFJ7APCiKGc1tdAEOgeTNy3SsB491S3aHn4S4r3e976eUnPdU+NbdtmBuLncYir2tMU9Nw==",
 			"cpu": [
 				"x64"
 			],
@@ -182,9 +182,9 @@
 			}
 		},
 		"node_modules/@esbuild/linux-arm": {
-			"version": "0.27.5",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.5.tgz",
-			"integrity": "sha512-0wkVrYHG4sdCCN/bcwQ7yYMXACkaHc3UFeaEOwSVW6e5RycMageYAFv+JS2bKLwHyeKVUvtoVH+5/RHq0fgeFw==",
+			"version": "0.28.0",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.0.tgz",
+			"integrity": "sha512-CjaaREJagqJp7iTaNQjjidaNbCKYcd4IDkzbwwxtSvjI7NZm79qiHc8HqciMddQ6CKvJT6aBd8lO9kN/ZudLlw==",
 			"cpu": [
 				"arm"
 			],
@@ -199,9 +199,9 @@
 			}
 		},
 		"node_modules/@esbuild/linux-arm64": {
-			"version": "0.27.5",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.5.tgz",
-			"integrity": "sha512-euKkilsNOv7x/M1NKsx5znyprbpsRFIzTV6lWziqJch7yWYayfLtZzDxDTl+LSQDJYAjd9TVb/Kt5UKIrj2e4A==",
+			"version": "0.28.0",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.0.tgz",
+			"integrity": "sha512-RVyzfb3FWsGA55n6WY0MEIEPURL1FcbhFE6BffZEMEekfCzCIMtB5yyDcFnVbTnwk+CLAgTujmV/Lgvih56W+A==",
 			"cpu": [
 				"arm64"
 			],
@@ -216,9 +216,9 @@
 			}
 		},
 		"node_modules/@esbuild/linux-ia32": {
-			"version": "0.27.5",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.5.tgz",
-			"integrity": "sha512-hVRQX4+P3MS36NxOy24v/Cdsimy/5HYePw+tmPqnNN1fxV0bPrFWR6TMqwXPwoTM2VzbkA+4lbHWUKDd5ZDA/w==",
+			"version": "0.28.0",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.0.tgz",
+			"integrity": "sha512-KBnSTt1kxl9x70q+ydterVdl+Cn0H18ngRMRCEQfrbqdUuntQQ0LoMZv47uB97NljZFzY6HcfqEZ2SAyIUTQBQ==",
 			"cpu": [
 				"ia32"
 			],
@@ -233,9 +233,9 @@
 			}
 		},
 		"node_modules/@esbuild/linux-loong64": {
-			"version": "0.27.5",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.5.tgz",
-			"integrity": "sha512-mKqqRuOPALI8nDzhOBmIS0INvZOOFGGg5n1osGIXAx8oersceEbKd4t1ACNTHM3sJBXGFAlEgqM+svzjPot+ZQ==",
+			"version": "0.28.0",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.0.tgz",
+			"integrity": "sha512-zpSlUce1mnxzgBADvxKXX5sl8aYQHo2ezvMNI8I0lbblJtp8V4odlm3Yzlj7gPyt3T8ReksE6bK+pT3WD+aJRg==",
 			"cpu": [
 				"loong64"
 			],
@@ -250,9 +250,9 @@
 			}
 		},
 		"node_modules/@esbuild/linux-mips64el": {
-			"version": "0.27.5",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.5.tgz",
-			"integrity": "sha512-EE/QXH9IyaAj1qeuIV5+/GZkBTipgGO782Ff7Um3vPS9cvLhJJeATy4Ggxikz2inZ46KByamMn6GqtqyVjhenA==",
+			"version": "0.28.0",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.0.tgz",
+			"integrity": "sha512-2jIfP6mmjkdmeTlsX/9vmdmhBmKADrWqN7zcdtHIeNSCH1SqIoNI63cYsjQR8J+wGa4Y5izRcSHSm8K3QWmk3w==",
 			"cpu": [
 				"mips64el"
 			],
@@ -267,9 +267,9 @@
 			}
 		},
 		"node_modules/@esbuild/linux-ppc64": {
-			"version": "0.27.5",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.5.tgz",
-			"integrity": "sha512-0V2iF1RGxBf1b7/BjurA5jfkl7PtySjom1r6xOK2q9KWw/XCpAdtB6KNMO+9xx69yYfSCRR9FE0TyKfHA2eQMw==",
+			"version": "0.28.0",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.0.tgz",
+			"integrity": "sha512-bc0FE9wWeC0WBm49IQMPSPILRocGTQt3j5KPCA8os6VprfuJ7KD+5PzESSrJ6GmPIPJK965ZJHTUlSA6GNYEhg==",
 			"cpu": [
 				"ppc64"
 			],
@@ -284,9 +284,9 @@
 			}
 		},
 		"node_modules/@esbuild/linux-riscv64": {
-			"version": "0.27.5",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.5.tgz",
-			"integrity": "sha512-rYxThBx6G9HN6tFNuvB/vykeLi4VDsm5hE5pVwzqbAjZEARQrWu3noZSfbEnPZ/CRXP3271GyFk/49up2W190g==",
+			"version": "0.28.0",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.0.tgz",
+			"integrity": "sha512-SQPZOwoTTT/HXFXQJG/vBX8sOFagGqvZyXcgLA3NhIqcBv1BJU1d46c0rGcrij2B56Z2rNiSLaZOYW5cUk7yLQ==",
 			"cpu": [
 				"riscv64"
 			],
@@ -301,9 +301,9 @@
 			}
 		},
 		"node_modules/@esbuild/linux-s390x": {
-			"version": "0.27.5",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.5.tgz",
-			"integrity": "sha512-uEP2q/4qgd8goEUc4QIdU/1P2NmEtZ/zX5u3OpLlCGhJIuBIv0s0wr7TB2nBrd3/A5XIdEkkS5ZLF0ULuvaaYQ==",
+			"version": "0.28.0",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.0.tgz",
+			"integrity": "sha512-SCfR0HN8CEEjnYnySJTd2cw0k9OHB/YFzt5zgJEwa+wL/T/raGWYMBqwDNAC6dqFKmJYZoQBRfHjgwLHGSrn3Q==",
 			"cpu": [
 				"s390x"
 			],
@@ -318,9 +318,9 @@
 			}
 		},
 		"node_modules/@esbuild/linux-x64": {
-			"version": "0.27.5",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.5.tgz",
-			"integrity": "sha512-+Gq47Wqq6PLOOZuBzVSII2//9yyHNKZLuwfzCemqexqOQCSz0zy0O26kIzyp9EMNMK+nZ0tFHBZrCeVUuMs/ew==",
+			"version": "0.28.0",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.0.tgz",
+			"integrity": "sha512-us0dSb9iFxIi8srnpl931Nvs65it/Jd2a2K3qs7fz2WfGPHqzfzZTfec7oxZJRNPXPnNYZtanmRc4AL/JwVzHQ==",
 			"cpu": [
 				"x64"
 			],
@@ -335,9 +335,9 @@
 			}
 		},
 		"node_modules/@esbuild/netbsd-arm64": {
-			"version": "0.27.5",
-			"resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.5.tgz",
-			"integrity": "sha512-3F/5EG8VHfN/I+W5cO1/SV2H9Q/5r7vcHabMnBqhHK2lTWOh3F8vixNzo8lqxrlmBtZVFpW8pmITHnq54+Tq4g==",
+			"version": "0.28.0",
+			"resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.0.tgz",
+			"integrity": "sha512-CR/RYotgtCKwtftMwJlUU7xCVNg3lMYZ0RzTmAHSfLCXw3NtZtNpswLEj/Kkf6kEL3Gw+BpOekRX0BYCtklhUw==",
 			"cpu": [
 				"arm64"
 			],
@@ -352,9 +352,9 @@
 			}
 		},
 		"node_modules/@esbuild/netbsd-x64": {
-			"version": "0.27.5",
-			"resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.5.tgz",
-			"integrity": "sha512-28t+Sj3CPN8vkMOlZotOmDgilQwVvxWZl7b8rxpn73Tt/gCnvrHxQUMng4uu3itdFvrtba/1nHejvxqz8xgEMA==",
+			"version": "0.28.0",
+			"resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.0.tgz",
+			"integrity": "sha512-nU1yhmYutL+fQ71Kxnhg8uEOdC0pwEW9entHykTgEbna2pw2dkbFSMeqjjyHZoCmt8SBkOSvV+yNmm94aUrrqw==",
 			"cpu": [
 				"x64"
 			],
@@ -369,9 +369,9 @@
 			}
 		},
 		"node_modules/@esbuild/openbsd-arm64": {
-			"version": "0.27.5",
-			"resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.5.tgz",
-			"integrity": "sha512-Doz/hKtiuVAi9hMsBMpwBANhIZc8l238U2Onko3t2xUp8xtM0ZKdDYHMnm/qPFVthY8KtxkXaocwmMh6VolzMA==",
+			"version": "0.28.0",
+			"resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.0.tgz",
+			"integrity": "sha512-cXb5vApOsRsxsEl4mcZ1XY3D4DzcoMxR/nnc4IyqYs0rTI8ZKmW6kyyg+11Z8yvgMfAEldKzP7AdP64HnSC/6g==",
 			"cpu": [
 				"arm64"
 			],
@@ -386,9 +386,9 @@
 			}
 		},
 		"node_modules/@esbuild/openbsd-x64": {
-			"version": "0.27.5",
-			"resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.5.tgz",
-			"integrity": "sha512-WfGVaa1oz5A7+ZFPkERIbIhKT4olvGl1tyzTRaB5yoZRLqC0KwaO95FeZtOdQj/oKkjW57KcVF944m62/0GYtA==",
+			"version": "0.28.0",
+			"resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.0.tgz",
+			"integrity": "sha512-8wZM2qqtv9UP3mzy7HiGYNH/zjTA355mpeuA+859TyR+e+Tc08IHYpLJuMsfpDJwoLo1ikIJI8jC3GFjnRClzA==",
 			"cpu": [
 				"x64"
 			],
@@ -403,9 +403,9 @@
 			}
 		},
 		"node_modules/@esbuild/openharmony-arm64": {
-			"version": "0.27.5",
-			"resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.5.tgz",
-			"integrity": "sha512-Xh+VRuh6OMh3uJ0JkCjI57l+DVe7VRGBYymen8rFPnTVgATBwA6nmToxM2OwTlSvrnWpPKkrQUj93+K9huYC6A==",
+			"version": "0.28.0",
+			"resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.0.tgz",
+			"integrity": "sha512-FLGfyizszcef5C3YtoyQDACyg95+dndv79i2EekILBofh5wpCa1KuBqOWKrEHZg3zrL3t5ouE5jgr94vA+Wb2w==",
 			"cpu": [
 				"arm64"
 			],
@@ -420,9 +420,9 @@
 			}
 		},
 		"node_modules/@esbuild/sunos-x64": {
-			"version": "0.27.5",
-			"resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.5.tgz",
-			"integrity": "sha512-aC1gpJkkaUADHuAdQfuVTnqVUTLqqUNhAvEwHwVWcnVVZvNlDPGA0UveZsfXJJ9T6k9Po4eHi3c02gbdwO3g6w==",
+			"version": "0.28.0",
+			"resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.0.tgz",
+			"integrity": "sha512-1ZgjUoEdHZZl/YlV76TSCz9Hqj9h9YmMGAgAPYd+q4SicWNX3G5GCyx9uhQWSLcbvPW8Ni7lj4gDa1T40akdlw==",
 			"cpu": [
 				"x64"
 			],
@@ -437,9 +437,9 @@
 			}
 		},
 		"node_modules/@esbuild/win32-arm64": {
-			"version": "0.27.5",
-			"resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.5.tgz",
-			"integrity": "sha512-0UNx2aavV0fk6UpZcwXFLztA2r/k9jTUa7OW7SAea1VYUhkug99MW1uZeXEnPn5+cHOd0n8myQay6TlFnBR07w==",
+			"version": "0.28.0",
+			"resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.0.tgz",
+			"integrity": "sha512-Q9StnDmQ/enxnpxCCLSg0oo4+34B9TdXpuyPeTedN/6+iXBJ4J+zwfQI28u/Jl40nOYAxGoNi7mFP40RUtkmUA==",
 			"cpu": [
 				"arm64"
 			],
@@ -454,9 +454,9 @@
 			}
 		},
 		"node_modules/@esbuild/win32-ia32": {
-			"version": "0.27.5",
-			"resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.5.tgz",
-			"integrity": "sha512-5nlJ3AeJWCTSzR7AEqVjT/faWyqKU86kCi1lLmxVqmNR+j4HrYdns+eTGjS/vmrzCIe8inGQckUadvS0+JkKdQ==",
+			"version": "0.28.0",
+			"resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.0.tgz",
+			"integrity": "sha512-zF3ag/gfiCe6U2iczcRzSYJKH1DCI+ByzSENHlM2FcDbEeo5Zd2C86Aq0tKUYAJJ1obRP84ymxIAksZUcdztHA==",
 			"cpu": [
 				"ia32"
 			],
@@ -471,9 +471,9 @@
 			}
 		},
 		"node_modules/@esbuild/win32-x64": {
-			"version": "0.27.5",
-			"resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.5.tgz",
-			"integrity": "sha512-PWypQR+d4FLfkhBIV+/kHsUELAnMpx1bRvvsn3p+/sAERbnCzFrtDRG2Xw5n+2zPxBK2+iaP+vetsRl4Ti7WgA==",
+			"version": "0.28.0",
+			"resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.0.tgz",
+			"integrity": "sha512-pEl1bO9mfAmIC+tW5btTmrKaujg3zGtUmWNdCw/xs70FBjwAL3o9OEKNHvNmnyylD6ubxUERiEhdsL0xBQ9efw==",
 			"cpu": [
 				"x64"
 			],
@@ -831,19 +831,19 @@
 			"license": "MIT"
 		},
 		"node_modules/@types/node": {
-			"version": "25.5.0",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-25.5.0.tgz",
-			"integrity": "sha512-jp2P3tQMSxWugkCUKLRPVUpGaL5MVFwF8RDuSRztfwgN1wmqJeMSbKlnEtQqU8UrhTmzEmZdu2I6v2dpp7XIxw==",
+			"version": "25.9.1",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-25.9.1.tgz",
+			"integrity": "sha512-xfrlY7UD5rMJk3ZVJP8BNzS28J36YJg+xp+LPXV1TdWxr8uMH5A860QNxYDGQe/ylDSgjxE52Q9VnO7p75tJxg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"undici-types": "~7.18.0"
+				"undici-types": ">=7.24.0 <7.24.7"
 			}
 		},
 		"node_modules/@types/node/node_modules/undici-types": {
-			"version": "7.18.2",
-			"resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
-			"integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
+			"version": "7.24.6",
+			"resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.24.6.tgz",
+			"integrity": "sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==",
 			"dev": true,
 			"license": "MIT"
 		},
@@ -858,17 +858,17 @@
 			}
 		},
 		"node_modules/@typescript-eslint/eslint-plugin": {
-			"version": "8.58.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.58.0.tgz",
-			"integrity": "sha512-RLkVSiNuUP1C2ROIWfqX+YcUfLaSnxGE/8M+Y57lopVwg9VTYYfhuz15Yf1IzCKgZj6/rIbYTmJCUSqr76r0Wg==",
+			"version": "8.60.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.60.0.tgz",
+			"integrity": "sha512-QYb/sa74/s7OKMbACMjrYnGspj9Hs5YI5aaffSL65UfeBUzVzBJfVo3oWSpbzPurvm7yaCCo2Lk7lVj610HqKw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@eslint-community/regexpp": "^4.12.2",
-				"@typescript-eslint/scope-manager": "8.58.0",
-				"@typescript-eslint/type-utils": "8.58.0",
-				"@typescript-eslint/utils": "8.58.0",
-				"@typescript-eslint/visitor-keys": "8.58.0",
+				"@typescript-eslint/scope-manager": "8.60.0",
+				"@typescript-eslint/type-utils": "8.60.0",
+				"@typescript-eslint/utils": "8.60.0",
+				"@typescript-eslint/visitor-keys": "8.60.0",
 				"ignore": "^7.0.5",
 				"natural-compare": "^1.4.0",
 				"ts-api-utils": "^2.5.0"
@@ -881,7 +881,7 @@
 				"url": "https://opencollective.com/typescript-eslint"
 			},
 			"peerDependencies": {
-				"@typescript-eslint/parser": "^8.58.0",
+				"@typescript-eslint/parser": "^8.60.0",
 				"eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
 				"typescript": ">=4.8.4 <6.1.0"
 			}
@@ -897,16 +897,16 @@
 			}
 		},
 		"node_modules/@typescript-eslint/parser": {
-			"version": "8.58.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.58.0.tgz",
-			"integrity": "sha512-rLoGZIf9afaRBYsPUMtvkDWykwXwUPL60HebR4JgTI8mxfFe2cQTu3AGitANp4b9B2QlVru6WzjgB2IzJKiCSA==",
+			"version": "8.60.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.60.0.tgz",
+			"integrity": "sha512-fcqpj/MyK4sxDPcbe7STNPbpQL4RLZOPWuaTmwZYuc+hJKzRf58yRxfhqGpc6PIq9ZyfSBpfHgmUHmHs0KwHwg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@typescript-eslint/scope-manager": "8.58.0",
-				"@typescript-eslint/types": "8.58.0",
-				"@typescript-eslint/typescript-estree": "8.58.0",
-				"@typescript-eslint/visitor-keys": "8.58.0",
+				"@typescript-eslint/scope-manager": "8.60.0",
+				"@typescript-eslint/types": "8.60.0",
+				"@typescript-eslint/typescript-estree": "8.60.0",
+				"@typescript-eslint/visitor-keys": "8.60.0",
 				"debug": "^4.4.3"
 			},
 			"engines": {
@@ -922,14 +922,14 @@
 			}
 		},
 		"node_modules/@typescript-eslint/project-service": {
-			"version": "8.58.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.58.0.tgz",
-			"integrity": "sha512-8Q/wBPWLQP1j16NxoPNIKpDZFMaxl7yWIoqXWYeWO+Bbd2mjgvoF0dxP2jKZg5+x49rgKdf7Ck473M8PC3V9lg==",
+			"version": "8.60.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.60.0.tgz",
+			"integrity": "sha512-aZu74NNKJeUWqCjDddzdiKaS82dgYgV/vmf+Ui3ZdZejmgfXR/q+pRumgobnQ2cCJTgGTWp4ypiwsuofFubavg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@typescript-eslint/tsconfig-utils": "^8.58.0",
-				"@typescript-eslint/types": "^8.58.0",
+				"@typescript-eslint/tsconfig-utils": "^8.60.0",
+				"@typescript-eslint/types": "^8.60.0",
 				"debug": "^4.4.3"
 			},
 			"engines": {
@@ -944,14 +944,14 @@
 			}
 		},
 		"node_modules/@typescript-eslint/scope-manager": {
-			"version": "8.58.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.58.0.tgz",
-			"integrity": "sha512-W1Lur1oF50FxSnNdGp3Vs6P+yBRSmZiw4IIjEeYxd8UQJwhUF0gDgDD/W/Tgmh73mxgEU3qX0Bzdl/NGuSPEpQ==",
+			"version": "8.60.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.60.0.tgz",
+			"integrity": "sha512-pFzqhllJMs+jghLQWzV00ds39xLzuyqPSev5pd8f4Ir0rtKR3ZLUB4/4dhjOFighWb9larvtfJvqL+4yKDI3Xw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@typescript-eslint/types": "8.58.0",
-				"@typescript-eslint/visitor-keys": "8.58.0"
+				"@typescript-eslint/types": "8.60.0",
+				"@typescript-eslint/visitor-keys": "8.60.0"
 			},
 			"engines": {
 				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -962,9 +962,9 @@
 			}
 		},
 		"node_modules/@typescript-eslint/tsconfig-utils": {
-			"version": "8.58.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.58.0.tgz",
-			"integrity": "sha512-doNSZEVJsWEu4htiVC+PR6NpM+pa+a4ClH9INRWOWCUzMst/VA9c4gXq92F8GUD1rwhNvRLkgjfYtFXegXQF7A==",
+			"version": "8.60.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.60.0.tgz",
+			"integrity": "sha512-BZPR3RGYlAXnly6ymAxfkVn5rCbZzQNou0rxv3GfWZ8cTQp+hhVd73khbGLAd8k1TlAPLISH337M+tAgAnaJDQ==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -979,15 +979,15 @@
 			}
 		},
 		"node_modules/@typescript-eslint/type-utils": {
-			"version": "8.58.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.58.0.tgz",
-			"integrity": "sha512-aGsCQImkDIqMyx1u4PrVlbi/krmDsQUs4zAcCV6M7yPcPev+RqVlndsJy9kJ8TLihW9TZ0kbDAzctpLn5o+lOg==",
+			"version": "8.60.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.60.0.tgz",
+			"integrity": "sha512-SX46wEUtitCpq7AN38HkUU/+zvUpdKf7ephtWAFgckH8O7PQIyL5gvrhQgBLuEYgLfuKWOVvWVskMbuFHAz5xg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@typescript-eslint/types": "8.58.0",
-				"@typescript-eslint/typescript-estree": "8.58.0",
-				"@typescript-eslint/utils": "8.58.0",
+				"@typescript-eslint/types": "8.60.0",
+				"@typescript-eslint/typescript-estree": "8.60.0",
+				"@typescript-eslint/utils": "8.60.0",
 				"debug": "^4.4.3",
 				"ts-api-utils": "^2.5.0"
 			},
@@ -1004,9 +1004,9 @@
 			}
 		},
 		"node_modules/@typescript-eslint/types": {
-			"version": "8.58.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.58.0.tgz",
-			"integrity": "sha512-O9CjxypDT89fbHxRfETNoAnHj/i6IpRK0CvbVN3qibxlLdo5p5hcLmUuCCrHMpxiWSwKyI8mCP7qRNYuOJ0Uww==",
+			"version": "8.60.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.60.0.tgz",
+			"integrity": "sha512-AsE7x2XaAK+CVbeih0Fvbn+r1qHxtpLDJ3XUuFcIinT318T90yHMJC+Zgv+jUuDjQQd06HKwxnDu6sz1IcTilA==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -1018,16 +1018,16 @@
 			}
 		},
 		"node_modules/@typescript-eslint/typescript-estree": {
-			"version": "8.58.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.58.0.tgz",
-			"integrity": "sha512-7vv5UWbHqew/dvs+D3e1RvLv1v2eeZ9txRHPnEEBUgSNLx5ghdzjHa0sgLWYVKssH+lYmV0JaWdoubo0ncGYLA==",
+			"version": "8.60.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.60.0.tgz",
+			"integrity": "sha512-3AcZNBGMClm6CXDyo8kYvVGT/sx29sS0oBsIb9oZI2gunA4Vm2M3YHzRLPvsUBBsl+yB5FPtltq7gGH0iTlp9g==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@typescript-eslint/project-service": "8.58.0",
-				"@typescript-eslint/tsconfig-utils": "8.58.0",
-				"@typescript-eslint/types": "8.58.0",
-				"@typescript-eslint/visitor-keys": "8.58.0",
+				"@typescript-eslint/project-service": "8.60.0",
+				"@typescript-eslint/tsconfig-utils": "8.60.0",
+				"@typescript-eslint/types": "8.60.0",
+				"@typescript-eslint/visitor-keys": "8.60.0",
 				"debug": "^4.4.3",
 				"minimatch": "^10.2.2",
 				"semver": "^7.7.3",
@@ -1056,9 +1056,9 @@
 			}
 		},
 		"node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion": {
-			"version": "5.0.5",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
-			"integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+			"version": "5.0.6",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+			"integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -1085,9 +1085,9 @@
 			}
 		},
 		"node_modules/@typescript-eslint/typescript-estree/node_modules/semver": {
-			"version": "7.7.4",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
-			"integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+			"version": "7.8.1",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.8.1.tgz",
+			"integrity": "sha512-rkVq3IXh+4FDGch+KwzX3aV9W3kO54GyEgpvBzSyctDA6Xtd7RJQV1xmXbeQp5v7+VzLOfVqiutSE6GICgPFvg==",
 			"dev": true,
 			"license": "ISC",
 			"bin": {
@@ -1098,16 +1098,16 @@
 			}
 		},
 		"node_modules/@typescript-eslint/utils": {
-			"version": "8.58.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.58.0.tgz",
-			"integrity": "sha512-RfeSqcFeHMHlAWzt4TBjWOAtoW9lnsAGiP3GbaX9uVgTYYrMbVnGONEfUCiSss+xMHFl+eHZiipmA8WkQ7FuNA==",
+			"version": "8.60.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.60.0.tgz",
+			"integrity": "sha512-HtXuPfrHTyBDkameWpl+vJb1Uevu2tznAyahM1Oc4AENidCLTPiZDWIo4GfcxNdC/RcfGcadzzkqbRG87dUrQA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@eslint-community/eslint-utils": "^4.9.1",
-				"@typescript-eslint/scope-manager": "8.58.0",
-				"@typescript-eslint/types": "8.58.0",
-				"@typescript-eslint/typescript-estree": "8.58.0"
+				"@typescript-eslint/scope-manager": "8.60.0",
+				"@typescript-eslint/types": "8.60.0",
+				"@typescript-eslint/typescript-estree": "8.60.0"
 			},
 			"engines": {
 				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -1122,13 +1122,13 @@
 			}
 		},
 		"node_modules/@typescript-eslint/visitor-keys": {
-			"version": "8.58.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.58.0.tgz",
-			"integrity": "sha512-XJ9UD9+bbDo4a4epraTwG3TsNPeiB9aShrUneAVXy8q4LuwowN+qu89/6ByLMINqvIMeI9H9hOHQtg/ijrYXzQ==",
+			"version": "8.60.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.60.0.tgz",
+			"integrity": "sha512-9WI52t8ZGLVGrPMBet25yAftqY/n95+zmoUUtJBBQTKDSKUu7OsPTroT2op7U9JatkoRccL0YkWDNMFfC4Sjxg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@typescript-eslint/types": "8.58.0",
+				"@typescript-eslint/types": "8.60.0",
 				"eslint-visitor-keys": "^5.0.0"
 			},
 			"engines": {
@@ -1891,9 +1891,9 @@
 			}
 		},
 		"node_modules/esbuild": {
-			"version": "0.27.5",
-			"resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.5.tgz",
-			"integrity": "sha512-zdQoHBjuDqKsvV5OPaWansOwfSQ0Js+Uj9J85TBvj3bFW1JjWTSULMRwdQAc8qMeIScbClxeMK0jlrtB9linhA==",
+			"version": "0.28.0",
+			"resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.0.tgz",
+			"integrity": "sha512-sNR9MHpXSUV/XB4zmsFKN+QgVG82Cc7+/aaxJ8Adi8hyOac+EXptIp45QBPaVyX3N70664wRbTcLTOemCAnyqw==",
 			"dev": true,
 			"hasInstallScript": true,
 			"license": "MIT",
@@ -1904,32 +1904,32 @@
 				"node": ">=18"
 			},
 			"optionalDependencies": {
-				"@esbuild/aix-ppc64": "0.27.5",
-				"@esbuild/android-arm": "0.27.5",
-				"@esbuild/android-arm64": "0.27.5",
-				"@esbuild/android-x64": "0.27.5",
-				"@esbuild/darwin-arm64": "0.27.5",
-				"@esbuild/darwin-x64": "0.27.5",
-				"@esbuild/freebsd-arm64": "0.27.5",
-				"@esbuild/freebsd-x64": "0.27.5",
-				"@esbuild/linux-arm": "0.27.5",
-				"@esbuild/linux-arm64": "0.27.5",
-				"@esbuild/linux-ia32": "0.27.5",
-				"@esbuild/linux-loong64": "0.27.5",
-				"@esbuild/linux-mips64el": "0.27.5",
-				"@esbuild/linux-ppc64": "0.27.5",
-				"@esbuild/linux-riscv64": "0.27.5",
-				"@esbuild/linux-s390x": "0.27.5",
-				"@esbuild/linux-x64": "0.27.5",
-				"@esbuild/netbsd-arm64": "0.27.5",
-				"@esbuild/netbsd-x64": "0.27.5",
-				"@esbuild/openbsd-arm64": "0.27.5",
-				"@esbuild/openbsd-x64": "0.27.5",
-				"@esbuild/openharmony-arm64": "0.27.5",
-				"@esbuild/sunos-x64": "0.27.5",
-				"@esbuild/win32-arm64": "0.27.5",
-				"@esbuild/win32-ia32": "0.27.5",
-				"@esbuild/win32-x64": "0.27.5"
+				"@esbuild/aix-ppc64": "0.28.0",
+				"@esbuild/android-arm": "0.28.0",
+				"@esbuild/android-arm64": "0.28.0",
+				"@esbuild/android-x64": "0.28.0",
+				"@esbuild/darwin-arm64": "0.28.0",
+				"@esbuild/darwin-x64": "0.28.0",
+				"@esbuild/freebsd-arm64": "0.28.0",
+				"@esbuild/freebsd-x64": "0.28.0",
+				"@esbuild/linux-arm": "0.28.0",
+				"@esbuild/linux-arm64": "0.28.0",
+				"@esbuild/linux-ia32": "0.28.0",
+				"@esbuild/linux-loong64": "0.28.0",
+				"@esbuild/linux-mips64el": "0.28.0",
+				"@esbuild/linux-ppc64": "0.28.0",
+				"@esbuild/linux-riscv64": "0.28.0",
+				"@esbuild/linux-s390x": "0.28.0",
+				"@esbuild/linux-x64": "0.28.0",
+				"@esbuild/netbsd-arm64": "0.28.0",
+				"@esbuild/netbsd-x64": "0.28.0",
+				"@esbuild/openbsd-arm64": "0.28.0",
+				"@esbuild/openbsd-x64": "0.28.0",
+				"@esbuild/openharmony-arm64": "0.28.0",
+				"@esbuild/sunos-x64": "0.28.0",
+				"@esbuild/win32-arm64": "0.28.0",
+				"@esbuild/win32-ia32": "0.28.0",
+				"@esbuild/win32-x64": "0.28.0"
 			}
 		},
 		"node_modules/escape-string-regexp": {
@@ -2393,20 +2393,6 @@
 				"undici-types": "~5.26.4"
 			}
 		},
-		"node_modules/eslint-plugin-obsidianmd/node_modules/@typescript-eslint/types": {
-			"version": "8.33.1",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.33.1.tgz",
-			"integrity": "sha512-xid1WfizGhy/TKMTwhtVOgalHwPtV8T32MS9MaH50Cwvz6x6YqRIPdD2WvW0XaqOzTV9p5xdLY0h/ZusU5Lokg==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/typescript-eslint"
-			}
-		},
 		"node_modules/eslint-plugin-obsidianmd/node_modules/globals": {
 			"version": "14.0.0",
 			"resolved": "https://registry.npmjs.org/globals/-/globals-14.0.0.tgz",
@@ -2418,6 +2404,21 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/eslint-plugin-obsidianmd/node_modules/obsidian": {
+			"version": "1.12.3",
+			"resolved": "https://registry.npmjs.org/obsidian/-/obsidian-1.12.3.tgz",
+			"integrity": "sha512-HxWqe763dOqzXjnNiHmAJTRERN8KILBSqxDSEqbeSr7W8R8Jxezzbca+nz1LiiqXnMpM8lV2jzAezw3CZ4xNUw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@types/codemirror": "5.60.8",
+				"moment": "2.29.4"
+			},
+			"peerDependencies": {
+				"@codemirror/state": "6.5.0",
+				"@codemirror/view": "6.38.6"
 			}
 		},
 		"node_modules/eslint-plugin-obsidianmd/node_modules/semver": {
@@ -3470,9 +3471,9 @@
 			}
 		},
 		"node_modules/jiti": {
-			"version": "2.6.1",
-			"resolved": "https://registry.npmjs.org/jiti/-/jiti-2.6.1.tgz",
-			"integrity": "sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==",
+			"version": "2.7.0",
+			"resolved": "https://registry.npmjs.org/jiti/-/jiti-2.7.0.tgz",
+			"integrity": "sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ==",
 			"dev": true,
 			"license": "MIT",
 			"bin": {
@@ -3894,9 +3895,9 @@
 			}
 		},
 		"node_modules/obsidian": {
-			"version": "1.12.3",
-			"resolved": "https://registry.npmjs.org/obsidian/-/obsidian-1.12.3.tgz",
-			"integrity": "sha512-HxWqe763dOqzXjnNiHmAJTRERN8KILBSqxDSEqbeSr7W8R8Jxezzbca+nz1LiiqXnMpM8lV2jzAezw3CZ4xNUw==",
+			"version": "1.13.0",
+			"resolved": "https://registry.npmjs.org/obsidian/-/obsidian-1.13.0.tgz",
+			"integrity": "sha512-PHw5+SAPlJ0S3leFvJ0wgFg63Z3DavxL6+d1ll+8toXR2ZlYKc1rMWqdUv9LgUbTwPQUyY6yfhOMMivampRRiQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -4821,9 +4822,9 @@
 			}
 		},
 		"node_modules/typescript": {
-			"version": "5.8.3",
-			"resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.3.tgz",
-			"integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
+			"version": "6.0.3",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+			"integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"bin": {
@@ -4835,16 +4836,16 @@
 			}
 		},
 		"node_modules/typescript-eslint": {
-			"version": "8.58.0",
-			"resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.58.0.tgz",
-			"integrity": "sha512-e2TQzKfaI85fO+F3QywtX+tCTsu/D3WW5LVU6nz8hTFKFZ8yBJ6mSYRpXqdR3mFjPWmO0eWsTa5f+UpAOe/FMA==",
+			"version": "8.60.0",
+			"resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.60.0.tgz",
+			"integrity": "sha512-9f65qWLZdAW9m1JaxBDUHcqRUfL8bkxxXL7XxEfI+F09q56PkBvIfCjLF3yInsDM/BBmwkqmCQdCZe/RYlIWEw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@typescript-eslint/eslint-plugin": "8.58.0",
-				"@typescript-eslint/parser": "8.58.0",
-				"@typescript-eslint/typescript-estree": "8.58.0",
-				"@typescript-eslint/utils": "8.58.0"
+				"@typescript-eslint/eslint-plugin": "8.60.0",
+				"@typescript-eslint/parser": "8.60.0",
+				"@typescript-eslint/typescript-estree": "8.60.0",
+				"@typescript-eslint/utils": "8.60.0"
 			},
 			"engines": {
 				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"

--- a/package.json
+++ b/package.json
@@ -14,13 +14,13 @@
 	"license": "MIT",
 	"devDependencies": {
 		"@eslint/js": "9.39.4",
-		"@types/node": "^25.5.0",
-		"esbuild": "0.27.5",
+		"@types/node": "^25.9.1",
+		"esbuild": "0.28.0",
 		"eslint-plugin-obsidianmd": "0.3.0",
-		"jiti": "2.6.1",
-		"obsidian": "1.12.3",
+		"jiti": "2.7.0",
+		"obsidian": "1.13.0",
 		"tslib": "2.8.1",
-		"typescript": "5.8.3",
-		"typescript-eslint": "8.58.0"
+		"typescript": "6.0.3",
+		"typescript-eslint": "8.60.0"
 	}
 }

--- a/src/confirm-modal.ts
+++ b/src/confirm-modal.ts
@@ -32,6 +32,7 @@ class ConfirmModal extends Modal {
 			.addButton(btn => {
 				btn.setButtonText(this.confirmText);
 				if (this.confirmStyle === "warning") {
+					// eslint-disable-next-line @typescript-eslint/no-deprecated -- setDestructive() requires Obsidian 1.13.0; setWarning keeps minAppVersion at 1.8.7
 					btn.setWarning();
 				} else {
 					btn.setCta();

--- a/src/main.ts
+++ b/src/main.ts
@@ -7,7 +7,7 @@ import {removeSelectionProperty} from "./remove-selection-property";
 import {isFileSelected, setSelection} from "./toggle-selection";
 
 export default class BulkPropertiesPlugin extends Plugin {
-	settings!: BulkPropertiesSettings;
+	declare settings: BulkPropertiesSettings;
 	private statusBarEl: HTMLElement | null = null;
 	private statusBarTimer: number | null = null;
 	private saveQueue: Promise<void> = Promise.resolve();

--- a/src/remove-selection-property.ts
+++ b/src/remove-selection-property.ts
@@ -43,6 +43,7 @@ class ConfirmRemoveModal extends Modal {
 				.onClick(() => this.close()))
 			.addButton(btn => btn
 				.setButtonText("Remove")
+				// eslint-disable-next-line @typescript-eslint/no-deprecated -- setDestructive() requires Obsidian 1.13.0; setWarning keeps minAppVersion at 1.8.7
 				.setWarning()
 				.onClick(() => {
 					this.confirmed = true;

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -149,7 +149,16 @@ export class BulkPropertiesSettingTab extends PluginSettingTab {
 		}
 	}
 
-	display(): void {
+	// The imperative display() API is deprecated since Obsidian 1.13.0 in favour
+	// of declarative getSettingDefinitions(), but it remains fully supported.
+	// We intentionally keep the imperative model; this helper centralises the
+	// re-render so the single deprecation suppression lives in one place.
+	private rerender(): void {
+		// eslint-disable-next-line @typescript-eslint/no-deprecated -- imperative settings API still supported; see note above
+		this.display();
+	}
+
+	override display(): void {
 		const {containerEl} = this;
 		containerEl.empty();
 
@@ -309,7 +318,7 @@ export class BulkPropertiesSettingTab extends PluginSettingTab {
 							(_, idx) => idx !== i,
 						);
 						if (await this.updateSetting("properties", updated)) {
-							this.display();
+							this.rerender();
 						}
 					}));
 		}
@@ -408,7 +417,7 @@ export class BulkPropertiesSettingTab extends PluginSettingTab {
 							{name: newName, type: newType},
 						];
 						if (await this.updateSetting("properties", updated)) {
-							this.display();
+							this.rerender();
 						}
 					});
 			});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,5 @@
 {
 	"compilerOptions": {
-		"baseUrl": "src",
 		"inlineSourceMap": true,
 		"inlineSources": true,
 		"module": "ESNext",
@@ -8,7 +7,7 @@
 		"allowJs": true,
 		"strict": true,
 		"noImplicitReturns": true,
-		"moduleResolution": "node",
+		"moduleResolution": "bundler",
 		"importHelpers": true,
 		"noUncheckedIndexedAccess": true,
 		"exactOptionalPropertyTypes": true,


### PR DESCRIPTION
Updates all devDependencies to their latest versions, with one held back, and adapts the source to the two major bumps (TypeScript 6, Obsidian 1.13.0 typings).

## Version changes
| Package | From | To |
|---|---|---|
| `@types/node` | 25.5.0 | 25.9.1 |
| `esbuild` | 0.27.5 | 0.28.0 |
| `jiti` | 2.6.1 | 2.7.0 |
| `obsidian` | 1.12.3 | 1.13.0 |
| `typescript` | 5.8.3 | 6.0.3 |
| `typescript-eslint` | 8.58.0 | 8.60.0 |
| `@eslint/js` | 9.39.4 | held |

`@eslint/js` stays on 9.x because `eslint-plugin-obsidianmd@0.3.0` peer-pins `@eslint/js: "^9.30.1"`; moving to the ESLint 10 ecosystem would break that peer dependency.

## Source changes required by the major bumps
- **tsconfig**: TypeScript 6 turns `baseUrl` and `moduleResolution: "node"` (node10) into hard errors. Removed the unused `baseUrl` (all imports are relative) and switched `moduleResolution` to `"bundler"`, which matches the esbuild/ESNext setup.
- **main.ts**: Obsidian 1.13.0 adds `Plugin.settings?: unknown` as a base member. Changed `settings!:` to `declare settings:` to refine the inherited type, per the typings' own guidance.
- **settings.ts**: `PluginSettingTab.display()` now requires an `override` modifier. Internal re-renders route through a new `rerender()` helper holding a single justified `@typescript-eslint/no-deprecated` suppression; the imperative settings API remains fully supported and is retained intentionally.
- **confirm-modal.ts / remove-selection-property.ts**: kept `setWarning()` (with a justified suppression) rather than `setDestructive()`, which would require raising `minAppVersion` from 1.8.7 to 1.13.0.

`minAppVersion` is unchanged at 1.8.7.

## Verification
- `npm run build` (tsc type-check + esbuild production) passes
- `npm run lint` exits clean
- `npm install` reports 0 vulnerabilities
- Manual smoke test in Obsidian: settings add/remove re-render, settings persistence, warning buttons, and an end-to-end bulk edit all work