### PR TITLE
Fix behavioral bugs in settings skill examples

### DIFF
--- a/.claude/skills/settings/examples/migration-simple.md
+++ b/.claude/skills/settings/examples/migration-simple.md
@@ -111,7 +111,7 @@ class MyTab extends PluginSettingTab {
                     key: 'cacheKey',
                     placeholder: 'default',
                     validate: (value: string) =>
-                        /^[a-z0-9]*$/i.test(value.trim()) ? undefined : 'Use letters and digits only.',
+                        /^[a-z0-9]*$/i.test(value) ? undefined : 'Use letters and digits only.',
                 },
             },
         ];
@@ -124,6 +124,7 @@ class MyTab extends PluginSettingTab {
 - `display()` is gone. The framework renders from the array.
 - All three settings collapse to `control` definitions. The framework reads `this.plugin.settings[key]`, writes changes back, and calls `saveData()` for you.
 - The `cacheKey` rejection-on-invalid logic moved from a custom `onChange` into a `validate` callback. The framework now shows an inline error message when the input doesn't match.
+  - **One behavioral difference:** the original `onChange` trimmed the value before saving (`value.trim()`), so surrounding whitespace was silently normalized away. `validate` can only accept or reject — it can't transform the value the framework persists. So we validate the **raw** value (no `.trim()`): `" abc "` now fails validation with the error message instead of being saved with spaces. If you must normalize rather than reject (trim, lowercase, etc.), keep a `render` callback — see "When to keep `render`" below.
 - Imports drop `Setting` (no longer needed).
 
 Update your manifest:
@@ -182,7 +183,7 @@ class MyTab extends PluginSettingTab {
                     key: 'cacheKey',
                     placeholder: 'default',
                     validate: (value: string) =>
-                        /^[a-z0-9]*$/i.test(value.trim()) ? undefined : 'Use letters and digits only.',
+                        /^[a-z0-9]*$/i.test(value) ? undefined : 'Use letters and digits only.',
                 },
             },
         ];
@@ -219,6 +220,7 @@ class MyTab extends PluginSettingTab {
 
 In Path A above, the `cacheKey` validation moved from a hand-rolled `onChange` into `validate`. That works whenever the rejection is purely about the value's shape (regex, range, format). But there are cases where `control` + `validate` isn't enough and `render` is the right tool:
 
+- **Normalization** before saving (trim, lowercase, collapse whitespace). `validate` can only accept or reject the value as typed; it can't rewrite what gets persisted. If you want `" abc "` saved as `"abc"` rather than rejected, normalize in a `render` `onChange`.
 - **Side effects** on change (call a method, update a status bar, refresh another view).
 - **Inverted or derived values** (toggle drives a string config, slider drives a complex calculation).
 - **Custom suggesters** beyond `file`/`folder` (e.g. a command picker, tag picker).

--- a/.claude/skills/settings/examples/nested-settings.md
+++ b/.claude/skills/settings/examples/nested-settings.md
@@ -75,7 +75,18 @@ export default class MyPlugin extends Plugin {
     }
 
     async loadSettings() {
-        this.settings = Object.assign({}, DEFAULT_SETTINGS, await this.loadData());
+        // Merge each nested object explicitly. A shallow
+        // Object.assign({}, DEFAULT_SETTINGS, data) would let a stored partial
+        // object (e.g. { editor: { fontSize: 20 } }) replace the whole default
+        // editor object, dropping tabSize — and a null nested object would make
+        // predicates like settings.sync.enabled throw. Spreading null/undefined
+        // is a no-op, so missing or partial sections fall back to defaults.
+        let data: Partial<MySettings> = (await this.loadData()) ?? {};
+        this.settings = {
+            editor: { ...DEFAULT_SETTINGS.editor, ...data.editor },
+            sync: { ...DEFAULT_SETTINGS.sync, ...data.sync },
+            appearance: { ...DEFAULT_SETTINGS.appearance, ...data.appearance },
+        };
     }
 
     async saveSettings() {
@@ -159,7 +170,7 @@ Notes on the example:
 ## What you give up
 
 - **Compile-time `key` checking.** Dot-notation strings aren't statically verifiable against a nested type — `key: 'editor.fontSiz'` (typo) compiles. If you need it, generate a literal-union type for your dot-paths and pass it as the `K` parameter to `SettingDefinitionItem<K>` / `SettingControl<K>`.
-- **One source of truth for defaults.** The framework's per-control `defaultValue` only fires when `getControlValue` returns `undefined` — fine for missing leaf keys, but you have to seed the *shape* of the nested objects yourself (via `Object.assign` in `loadSettings`, as above) or `setPath` won't have anywhere to write.
+- **One source of truth for defaults.** The framework's per-control `defaultValue` only fires when `getControlValue` returns `undefined` — fine for missing leaf keys, but you have to seed the *shape* of the nested objects yourself (via the per-object merge in `loadSettings`, as above) or `setPath` won't have anywhere to write. A shallow `Object.assign` is **not** enough here: it merges only top-level keys, so a stored partial section overwrites its defaults wholesale and a `null` section breaks predicates that read through it.
 
 ## When this isn't enough
 

--- a/.claude/skills/settings/examples/page-navigation.md
+++ b/.claude/skills/settings/examples/page-navigation.md
@@ -92,8 +92,10 @@ class StatusPage extends SettingPage {
 
     display() {
         this.containerEl.empty();
-        this.containerEl.createEl('p', { text: `Last sync: ${new Date().toLocaleTimeString()}` });
-        this.timer = window.setInterval(() => this.display(), 1000);
+        let lastSyncEl = this.containerEl.createEl('p');
+        let render = () => lastSyncEl.setText(`Last sync: ${new Date().toLocaleTimeString()}`);
+        render();
+        this.timer = window.setInterval(render, 1000);
     }
 
     hide() {
@@ -101,6 +103,8 @@ class StatusPage extends SettingPage {
     }
 }
 ```
+
+Note that the interval callback updates the element it captured — it does **not** call `this.display()`. Re-running `display()` on every tick would call `setInterval` again each second, leaking a new timer per tick while `this.timer` tracks only the most recent one (so `hide()` clears just one of many). Create the timer once; update the DOM from the callback.
 
 `hide()` is **not guaranteed** to run when the host window is destroyed without a graceful close (e.g. renderer crash). For state that *must* be released, register it on the plugin instead — plugin unload always runs on graceful shutdown.
 


### PR DESCRIPTION
Fixes three behavioral bugs in the settings-migration skill's canonical examples, surfaced by roborev review #944.

## page-navigation.md
The `hide()` cleanup example's interval callback called `this.display()`, which re-ran `setInterval` on every tick. Each second spawned a new interval while `this.timer` tracked only the most recent, so `hide()` cleared just one of many leaked timers. The interval is now created once and the callback updates the captured element directly.

## nested-settings.md
`loadSettings()` used a shallow `Object.assign({}, DEFAULT_SETTINGS, data)`. A partial stored section (e.g. `editor: { fontSize: 20 }`) replaced the whole default object and dropped sibling keys, and a `null` section made predicates like `settings.sync.enabled` throw. Each nested object is now merged explicitly. The prose that claimed `Object.assign` "seeds the shape" is corrected.

## migration-simple.md
The `validate` callback trimmed before testing (`value.trim()`), but the framework persists the raw value — so `" abc "` passed validation and was saved with whitespace, diverging from the original `onChange` that saved the trimmed value. `validate` can accept or reject but not transform, so it now validates the raw value (rejecting surrounding whitespace), with a note that normalization belongs in a `render` callback.

Rejecting whitespace is a deliberate change from the original trim-and-save behavior, chosen to keep the example fully declarative and honest about `validate`'s limits.