### PR TITLE
Update devDependencies and adapt to eslint-plugin-obsidianmd 0.4.1

### DIFF
--- a/eslint.config.mts
+++ b/eslint.config.mts
@@ -35,28 +35,10 @@ export default defineConfig(
 		},
 	},
 	{
-		// The obsidianmd preset forbids disabling no-deprecated, but our
-		// three suppressions are deliberate: the replacements
-		// (setDestructive, getSettingDefinitions) require Obsidian 1.13.0
-		// and we hold minAppVersion at 1.8.7. Keep the preset's list
-		// otherwise intact.
+		// We deliberately keep the imperative display() settings model for
+		// now; migrating to getSettingDefinitions() is planned separately.
 		files: ['**/*.{ts,cts,mts,tsx,js,cjs,mjs,jsx}'],
 		rules: {
-			"eslint-comments/no-restricted-disable": [
-				"error",
-				"obsidianmd/*",
-				"no-console",
-				"no-restricted-globals",
-				"@typescript-eslint/no-restricted-imports",
-				"no-alert",
-				"@typescript-eslint/no-explicit-any",
-				"@microsoft/sdl/no-document-write",
-				"no-eval",
-				"@microsoft/sdl/no-inner-html",
-				"obsidianmd/no-nodejs-modules",
-			],
-			// We deliberately keep the imperative display() settings model
-			// rather than migrating to getSettingDefinitions() (1.13.0+).
 			"obsidianmd/settings-tab/prefer-setting-definitions": "off",
 		},
 	},

--- a/eslint.config.mts
+++ b/eslint.config.mts
@@ -35,6 +35,32 @@ export default defineConfig(
 		},
 	},
 	{
+		// The obsidianmd preset forbids disabling no-deprecated, but our
+		// three suppressions are deliberate: the replacements
+		// (setDestructive, getSettingDefinitions) require Obsidian 1.13.0
+		// and we hold minAppVersion at 1.8.7. Keep the preset's list
+		// otherwise intact.
+		files: ['**/*.{ts,cts,mts,tsx,js,cjs,mjs,jsx}'],
+		rules: {
+			"eslint-comments/no-restricted-disable": [
+				"error",
+				"obsidianmd/*",
+				"no-console",
+				"no-restricted-globals",
+				"@typescript-eslint/no-restricted-imports",
+				"no-alert",
+				"@typescript-eslint/no-explicit-any",
+				"@microsoft/sdl/no-document-write",
+				"no-eval",
+				"@microsoft/sdl/no-inner-html",
+				"obsidianmd/no-nodejs-modules",
+			],
+			// We deliberately keep the imperative display() settings model
+			// rather than migrating to getSettingDefinitions() (1.13.0+).
+			"obsidianmd/settings-tab/prefer-setting-definitions": "off",
+		},
+	},
+	{
 		// The obsidianmd 0.2.x preset spreads its TS-typed rules globally,
 		// so they also apply to the package.json block that uses json/json
 		// (no parser services → crash). Match the preset's scope and

--- a/eslint.config.mts
+++ b/eslint.config.mts
@@ -4,12 +4,6 @@ import { defineConfig, globalIgnores } from "eslint/config";
 
 export default defineConfig(
 	{
-		// Report directive comments that silence rules which never fired.
-		// Obsidian's plugin reviewer enables this; without it, stale
-		// eslint-disable comments slip through local lint.
-		linterOptions: {
-			reportUnusedDisableDirectives: "error",
-		},
 		languageOptions: {
 			parserOptions: {
 				projectService: {
@@ -40,21 +34,6 @@ export default defineConfig(
 		files: ['**/*.{ts,cts,mts,tsx,js,cjs,mjs,jsx}'],
 		rules: {
 			"obsidianmd/settings-tab/prefer-setting-definitions": "off",
-		},
-	},
-	{
-		// The obsidianmd 0.2.x preset spreads its TS-typed rules globally,
-		// so they also apply to the package.json block that uses json/json
-		// (no parser services → crash). Match the preset's scope and
-		// disable the type-aware rules here; the preset's JSON-aware
-		// rules (validate-license, depend/ban-dependencies) still run.
-		files: ['package.json'],
-		rules: {
-			'obsidianmd/no-plugin-as-component': 'off',
-			'obsidianmd/no-view-references-in-plugin': 'off',
-			'obsidianmd/prefer-file-manager-trash-file': 'off',
-			'obsidianmd/prefer-instanceof': 'off',
-			'obsidianmd/no-unsupported-api': 'off',
 		},
 	},
 	globalIgnores([

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
 	"id": "bulk-properties",
 	"name": "Bulk Properties",
 	"version": "1.0.10",
-	"minAppVersion": "1.8.7",
+	"minAppVersion": "1.13.0",
 	"description": "Edit properties across multiple notes at once. Use a checkbox property to mark notes for updating.",
 	"author": "Gary Ritchie",
 	"isDesktopOnly": false,

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,15 +9,15 @@
 			"version": "1.0.10",
 			"license": "MIT",
 			"devDependencies": {
-				"@eslint/js": "9.39.4",
-				"@types/node": "^25.9.1",
-				"esbuild": "0.28.0",
-				"eslint-plugin-obsidianmd": "0.3.0",
+				"@eslint/js": "9.39.5",
+				"@types/node": "^26.1.1",
+				"esbuild": "0.28.1",
+				"eslint-plugin-obsidianmd": "0.4.1",
 				"jiti": "2.7.0",
-				"obsidian": "1.13.0",
+				"obsidian": "1.13.1",
 				"tslib": "2.8.1",
 				"typescript": "6.0.3",
-				"typescript-eslint": "8.60.0"
+				"typescript-eslint": "8.64.0"
 			}
 		},
 		"node_modules/@codemirror/state": {
@@ -46,9 +46,9 @@
 			}
 		},
 		"node_modules/@esbuild/aix-ppc64": {
-			"version": "0.28.0",
-			"resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.0.tgz",
-			"integrity": "sha512-lhRUCeuOyJQURhTxl4WkpFTjIsbDayJHih5kZC1giwE+MhIzAb7mEsQMqMf18rHLsrb5qI1tafG20mLxEWcWlA==",
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.1.tgz",
+			"integrity": "sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ==",
 			"cpu": [
 				"ppc64"
 			],
@@ -63,9 +63,9 @@
 			}
 		},
 		"node_modules/@esbuild/android-arm": {
-			"version": "0.28.0",
-			"resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.0.tgz",
-			"integrity": "sha512-wqh0ByljabXLKHeWXYLqoJ5jKC4XBaw6Hk08OfMrCRd2nP2ZQ5eleDZC41XHyCNgktBGYMbqnrJKq/K/lzPMSQ==",
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.1.tgz",
+			"integrity": "sha512-0k2F129Xdio1TdJfzJ8sy1Q47vUD2NnwdhiAf7drUN1EBTfPf4hsFCtmMgu/6m8JSzsBrlmVjudMBQqOfG8usQ==",
 			"cpu": [
 				"arm"
 			],
@@ -80,9 +80,9 @@
 			}
 		},
 		"node_modules/@esbuild/android-arm64": {
-			"version": "0.28.0",
-			"resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.0.tgz",
-			"integrity": "sha512-+WzIXQOSaGs33tLEgYPYe/yQHf0WTU0X42Jca3y8NWMbUVhp7rUnw+vAsRC/QiDrdD31IszMrZy+qwPOPjd+rw==",
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.1.tgz",
+			"integrity": "sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg==",
 			"cpu": [
 				"arm64"
 			],
@@ -97,9 +97,9 @@
 			}
 		},
 		"node_modules/@esbuild/android-x64": {
-			"version": "0.28.0",
-			"resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.0.tgz",
-			"integrity": "sha512-+VJggoaKhk2VNNqVL7f6S189UzShHC/mR9EE8rDdSkdpN0KflSwWY/gWjDrNxxisg8Fp1ZCD9jLMo4m0OUfeUA==",
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.1.tgz",
+			"integrity": "sha512-dbwY7ltSMDWsRatcRpCnES4F+im88OCUgGZjy52shC7GqHRE/cYlxNbB4Z4UpJswpcc4Qxd2oE/ufM0p61IKng==",
 			"cpu": [
 				"x64"
 			],
@@ -114,9 +114,9 @@
 			}
 		},
 		"node_modules/@esbuild/darwin-arm64": {
-			"version": "0.28.0",
-			"resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.0.tgz",
-			"integrity": "sha512-0T+A9WZm+bZ84nZBtk1ckYsOvyA3x7e2Acj1KdVfV4/2tdG4fzUp91YHx+GArWLtwqp77pBXVCPn2We7Letr0Q==",
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.1.tgz",
+			"integrity": "sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q==",
 			"cpu": [
 				"arm64"
 			],
@@ -131,9 +131,9 @@
 			}
 		},
 		"node_modules/@esbuild/darwin-x64": {
-			"version": "0.28.0",
-			"resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.0.tgz",
-			"integrity": "sha512-fyzLm/DLDl/84OCfp2f/XQ4flmORsjU7VKt8HLjvIXChJoFFOIL6pLJPH4Yhd1n1gGFF9mPwtlN5Wf82DZs+LQ==",
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.1.tgz",
+			"integrity": "sha512-zfdzgK9ACBNZLI/CyHTOx81SyNbM6YXn7rxSgX97VjyiPl9W1i4Ka4fgKECEoFCKGpvBj5qArWIGgQjOwkgskQ==",
 			"cpu": [
 				"x64"
 			],
@@ -148,9 +148,9 @@
 			}
 		},
 		"node_modules/@esbuild/freebsd-arm64": {
-			"version": "0.28.0",
-			"resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.0.tgz",
-			"integrity": "sha512-l9GeW5UZBT9k9brBYI+0WDffcRxgHQD8ShN2Ur4xWq/NFzUKm3k5lsH4PdaRgb2w7mI9u61nr2gI2mLI27Nh3Q==",
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.1.tgz",
+			"integrity": "sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw==",
 			"cpu": [
 				"arm64"
 			],
@@ -165,9 +165,9 @@
 			}
 		},
 		"node_modules/@esbuild/freebsd-x64": {
-			"version": "0.28.0",
-			"resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.0.tgz",
-			"integrity": "sha512-BXoQai/A0wPO6Es3yFJ7APCiKGc1tdAEOgeTNy3SsB491S3aHn4S4r3e976eUnPdU+NbdtmBuLncYir2tMU9Nw==",
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.1.tgz",
+			"integrity": "sha512-i7dZ9vQgnvSCzi/rYCXNgtF/U+eKZNJBzu3eTQbRgHnM7tNSizLOkRFAl3qzVc/Op/u5YkHHa4pf/3DOYHthLQ==",
 			"cpu": [
 				"x64"
 			],
@@ -182,9 +182,9 @@
 			}
 		},
 		"node_modules/@esbuild/linux-arm": {
-			"version": "0.28.0",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.0.tgz",
-			"integrity": "sha512-CjaaREJagqJp7iTaNQjjidaNbCKYcd4IDkzbwwxtSvjI7NZm79qiHc8HqciMddQ6CKvJT6aBd8lO9kN/ZudLlw==",
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.1.tgz",
+			"integrity": "sha512-qVXBOHQS+d5Y722GwJzJUtOLlX7km3CraOaGormF1pDtPd2C/l1SHRPgjLunLGe51Sh5YYWKMFDyV4SxgMQYTQ==",
 			"cpu": [
 				"arm"
 			],
@@ -199,9 +199,9 @@
 			}
 		},
 		"node_modules/@esbuild/linux-arm64": {
-			"version": "0.28.0",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.0.tgz",
-			"integrity": "sha512-RVyzfb3FWsGA55n6WY0MEIEPURL1FcbhFE6BffZEMEekfCzCIMtB5yyDcFnVbTnwk+CLAgTujmV/Lgvih56W+A==",
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.1.tgz",
+			"integrity": "sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g==",
 			"cpu": [
 				"arm64"
 			],
@@ -216,9 +216,9 @@
 			}
 		},
 		"node_modules/@esbuild/linux-ia32": {
-			"version": "0.28.0",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.0.tgz",
-			"integrity": "sha512-KBnSTt1kxl9x70q+ydterVdl+Cn0H18ngRMRCEQfrbqdUuntQQ0LoMZv47uB97NljZFzY6HcfqEZ2SAyIUTQBQ==",
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.1.tgz",
+			"integrity": "sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w==",
 			"cpu": [
 				"ia32"
 			],
@@ -233,9 +233,9 @@
 			}
 		},
 		"node_modules/@esbuild/linux-loong64": {
-			"version": "0.28.0",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.0.tgz",
-			"integrity": "sha512-zpSlUce1mnxzgBADvxKXX5sl8aYQHo2ezvMNI8I0lbblJtp8V4odlm3Yzlj7gPyt3T8ReksE6bK+pT3WD+aJRg==",
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.1.tgz",
+			"integrity": "sha512-M5sRjUVZrkm1OAPR3dlOYzNmN+loZKGVi1VUQGrwuqLcbR6qeAz+famMhjASeH3YVKvZz+zT1jlh/keC3Rj/lg==",
 			"cpu": [
 				"loong64"
 			],
@@ -250,9 +250,9 @@
 			}
 		},
 		"node_modules/@esbuild/linux-mips64el": {
-			"version": "0.28.0",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.0.tgz",
-			"integrity": "sha512-2jIfP6mmjkdmeTlsX/9vmdmhBmKADrWqN7zcdtHIeNSCH1SqIoNI63cYsjQR8J+wGa4Y5izRcSHSm8K3QWmk3w==",
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.1.tgz",
+			"integrity": "sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ==",
 			"cpu": [
 				"mips64el"
 			],
@@ -267,9 +267,9 @@
 			}
 		},
 		"node_modules/@esbuild/linux-ppc64": {
-			"version": "0.28.0",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.0.tgz",
-			"integrity": "sha512-bc0FE9wWeC0WBm49IQMPSPILRocGTQt3j5KPCA8os6VprfuJ7KD+5PzESSrJ6GmPIPJK965ZJHTUlSA6GNYEhg==",
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.1.tgz",
+			"integrity": "sha512-slScBsMAb3GFDcdrCgLwZtPYRoH2H/youv10QiZyRjmsP48fznoveWytSgCI/R0ZcUgpc0ZhIUEx6LHts8yrfQ==",
 			"cpu": [
 				"ppc64"
 			],
@@ -284,9 +284,9 @@
 			}
 		},
 		"node_modules/@esbuild/linux-riscv64": {
-			"version": "0.28.0",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.0.tgz",
-			"integrity": "sha512-SQPZOwoTTT/HXFXQJG/vBX8sOFagGqvZyXcgLA3NhIqcBv1BJU1d46c0rGcrij2B56Z2rNiSLaZOYW5cUk7yLQ==",
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.1.tgz",
+			"integrity": "sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ==",
 			"cpu": [
 				"riscv64"
 			],
@@ -301,9 +301,9 @@
 			}
 		},
 		"node_modules/@esbuild/linux-s390x": {
-			"version": "0.28.0",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.0.tgz",
-			"integrity": "sha512-SCfR0HN8CEEjnYnySJTd2cw0k9OHB/YFzt5zgJEwa+wL/T/raGWYMBqwDNAC6dqFKmJYZoQBRfHjgwLHGSrn3Q==",
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.1.tgz",
+			"integrity": "sha512-/lAIjX8aYFRByhh6L5rYtPEDRqa9de/4V/juOXcta5frjvzXO4/sqEtyytse0g3zZFuWu5cDN0MkLz2qRDD2Ag==",
 			"cpu": [
 				"s390x"
 			],
@@ -318,9 +318,9 @@
 			}
 		},
 		"node_modules/@esbuild/linux-x64": {
-			"version": "0.28.0",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.0.tgz",
-			"integrity": "sha512-us0dSb9iFxIi8srnpl931Nvs65it/Jd2a2K3qs7fz2WfGPHqzfzZTfec7oxZJRNPXPnNYZtanmRc4AL/JwVzHQ==",
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.1.tgz",
+			"integrity": "sha512-u/anNYF2mmVOEDwLtnQ1wOr3EZ9sTNGLWrsYGYwHWzGA3Si84IOkHXlbWTD1NB+9/1lcnweYKO54uhxZydNzfA==",
 			"cpu": [
 				"x64"
 			],
@@ -335,9 +335,9 @@
 			}
 		},
 		"node_modules/@esbuild/netbsd-arm64": {
-			"version": "0.28.0",
-			"resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.0.tgz",
-			"integrity": "sha512-CR/RYotgtCKwtftMwJlUU7xCVNg3lMYZ0RzTmAHSfLCXw3NtZtNpswLEj/Kkf6kEL3Gw+BpOekRX0BYCtklhUw==",
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.1.tgz",
+			"integrity": "sha512-oks0DYbLwWMmaakTsCb+zL4E+aHRVLom9IJZOAthMQEPiQmydXHkziYEsGYRx0uNV/IjEKGAV941JzH02pflqw==",
 			"cpu": [
 				"arm64"
 			],
@@ -352,9 +352,9 @@
 			}
 		},
 		"node_modules/@esbuild/netbsd-x64": {
-			"version": "0.28.0",
-			"resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.0.tgz",
-			"integrity": "sha512-nU1yhmYutL+fQ71Kxnhg8uEOdC0pwEW9entHykTgEbna2pw2dkbFSMeqjjyHZoCmt8SBkOSvV+yNmm94aUrrqw==",
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.1.tgz",
+			"integrity": "sha512-aeL6lAnN89Hz43Mlh1G8ARasbuoYvSITDEx0tHh5b7jJnHcssqgjy9Yx430GDpmCa6OyrKoS0aNRjKundRizGg==",
 			"cpu": [
 				"x64"
 			],
@@ -369,9 +369,9 @@
 			}
 		},
 		"node_modules/@esbuild/openbsd-arm64": {
-			"version": "0.28.0",
-			"resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.0.tgz",
-			"integrity": "sha512-cXb5vApOsRsxsEl4mcZ1XY3D4DzcoMxR/nnc4IyqYs0rTI8ZKmW6kyyg+11Z8yvgMfAEldKzP7AdP64HnSC/6g==",
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.1.tgz",
+			"integrity": "sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q==",
 			"cpu": [
 				"arm64"
 			],
@@ -386,9 +386,9 @@
 			}
 		},
 		"node_modules/@esbuild/openbsd-x64": {
-			"version": "0.28.0",
-			"resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.0.tgz",
-			"integrity": "sha512-8wZM2qqtv9UP3mzy7HiGYNH/zjTA355mpeuA+859TyR+e+Tc08IHYpLJuMsfpDJwoLo1ikIJI8jC3GFjnRClzA==",
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.1.tgz",
+			"integrity": "sha512-i/ZLIOafE0Z8cI/XANJAixoJL/uRAoS2xOA3rb0xN+KK0K177cMAsQYkzHtBrtMXAKuAc7HGgcWiZ/sRC1Nxgw==",
 			"cpu": [
 				"x64"
 			],
@@ -403,9 +403,9 @@
 			}
 		},
 		"node_modules/@esbuild/openharmony-arm64": {
-			"version": "0.28.0",
-			"resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.0.tgz",
-			"integrity": "sha512-FLGfyizszcef5C3YtoyQDACyg95+dndv79i2EekILBofh5wpCa1KuBqOWKrEHZg3zrL3t5ouE5jgr94vA+Wb2w==",
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.1.tgz",
+			"integrity": "sha512-ge+Z7EXFNt2BO1oAMsVpiQ8EwndV9i1xXerAeTIK7AtPs3bKFXQM7nlRxDSIUIMeueR1CNXxqztLzdNeReKBJg==",
 			"cpu": [
 				"arm64"
 			],
@@ -420,9 +420,9 @@
 			}
 		},
 		"node_modules/@esbuild/sunos-x64": {
-			"version": "0.28.0",
-			"resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.0.tgz",
-			"integrity": "sha512-1ZgjUoEdHZZl/YlV76TSCz9Hqj9h9YmMGAgAPYd+q4SicWNX3G5GCyx9uhQWSLcbvPW8Ni7lj4gDa1T40akdlw==",
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.1.tgz",
+			"integrity": "sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ==",
 			"cpu": [
 				"x64"
 			],
@@ -437,9 +437,9 @@
 			}
 		},
 		"node_modules/@esbuild/win32-arm64": {
-			"version": "0.28.0",
-			"resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.0.tgz",
-			"integrity": "sha512-Q9StnDmQ/enxnpxCCLSg0oo4+34B9TdXpuyPeTedN/6+iXBJ4J+zwfQI28u/Jl40nOYAxGoNi7mFP40RUtkmUA==",
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.1.tgz",
+			"integrity": "sha512-lCv9eK/H6ZJWbE7bh2nw54CZ9M2nupBxJcTsdk/QQnWkdSjKGuxmmH8/GWrlT1eMmZfn4dGcCjRte397WqfQXA==",
 			"cpu": [
 				"arm64"
 			],
@@ -454,9 +454,9 @@
 			}
 		},
 		"node_modules/@esbuild/win32-ia32": {
-			"version": "0.28.0",
-			"resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.0.tgz",
-			"integrity": "sha512-zF3ag/gfiCe6U2iczcRzSYJKH1DCI+ByzSENHlM2FcDbEeo5Zd2C86Aq0tKUYAJJ1obRP84ymxIAksZUcdztHA==",
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.1.tgz",
+			"integrity": "sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg==",
 			"cpu": [
 				"ia32"
 			],
@@ -471,9 +471,9 @@
 			}
 		},
 		"node_modules/@esbuild/win32-x64": {
-			"version": "0.28.0",
-			"resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.0.tgz",
-			"integrity": "sha512-pEl1bO9mfAmIC+tW5btTmrKaujg3zGtUmWNdCw/xs70FBjwAL3o9OEKNHvNmnyylD6ubxUERiEhdsL0xBQ9efw==",
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.1.tgz",
+			"integrity": "sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A==",
 			"cpu": [
 				"x64"
 			],
@@ -485,6 +485,36 @@
 			],
 			"engines": {
 				"node": ">=18"
+			}
+		},
+		"node_modules/@eslint-community/eslint-plugin-eslint-comments": {
+			"version": "4.7.2",
+			"resolved": "https://registry.npmjs.org/@eslint-community/eslint-plugin-eslint-comments/-/eslint-plugin-eslint-comments-4.7.2.tgz",
+			"integrity": "sha512-LF03qURSwEWm2dz5wtdDCzNk+7Opl0X7q6I3undsaIuNsEiNvRV3BCtqu14Q/6Pzg1tBj44LcxpW2EpSLZStZw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"escape-string-regexp": "^4.0.0",
+				"ignore": "^7.0.5"
+			},
+			"engines": {
+				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/eslint"
+			},
+			"peerDependencies": {
+				"eslint": "^6.0.0 || ^7.0.0 || ^8.0.0 || ^9.0.0 || ^10.0.0"
+			}
+		},
+		"node_modules/@eslint-community/eslint-plugin-eslint-comments/node_modules/ignore": {
+			"version": "7.0.6",
+			"resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.6.tgz",
+			"integrity": "sha512-BAg6QkE8W+TuQLrrw0Ugr7HegXduRuuj8/ti2kSOc+jz1dmx8/WNcjr6XGnq5YpDWxFwwaavqD0+jIUOKelTsw==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 4"
 			}
 		},
 		"node_modules/@eslint-community/eslint-utils": {
@@ -608,9 +638,9 @@
 			}
 		},
 		"node_modules/@eslint/js": {
-			"version": "9.39.4",
-			"resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.39.4.tgz",
-			"integrity": "sha512-nE7DEIchvtiFTwBw4Lfbu59PG+kCofhjsKaCWzxTpt4lfRjRMqG6uMBzKXuEcyXhOHoUp9riAm7/aWYGhXZ9cw==",
+			"version": "9.39.5",
+			"resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.39.5.tgz",
+			"integrity": "sha512-QywQuszQh77pIXCsq998c8hbhSTI/azTty1Z6N53dmAudKHhy573j3yvRLsX2BSp8YpLtoCEG8E9DJe+8zUh4A==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -831,19 +861,19 @@
 			"license": "MIT"
 		},
 		"node_modules/@types/node": {
-			"version": "25.9.1",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-25.9.1.tgz",
-			"integrity": "sha512-xfrlY7UD5rMJk3ZVJP8BNzS28J36YJg+xp+LPXV1TdWxr8uMH5A860QNxYDGQe/ylDSgjxE52Q9VnO7p75tJxg==",
+			"version": "26.1.1",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-26.1.1.tgz",
+			"integrity": "sha512-nxAkRSVkN1Y0JC1W8ky/fTfkGsMmcrRsbx+3XoZE+rMOX71kLYTV7fLXpqud1GpbpP5TuffXFqfX7fH2GgZREw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"undici-types": ">=7.24.0 <7.24.7"
+				"undici-types": "~8.3.0"
 			}
 		},
 		"node_modules/@types/node/node_modules/undici-types": {
-			"version": "7.24.6",
-			"resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.24.6.tgz",
-			"integrity": "sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==",
+			"version": "8.3.0",
+			"resolved": "https://registry.npmjs.org/undici-types/-/undici-types-8.3.0.tgz",
+			"integrity": "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==",
 			"dev": true,
 			"license": "MIT"
 		},
@@ -858,17 +888,17 @@
 			}
 		},
 		"node_modules/@typescript-eslint/eslint-plugin": {
-			"version": "8.60.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.60.0.tgz",
-			"integrity": "sha512-QYb/sa74/s7OKMbACMjrYnGspj9Hs5YI5aaffSL65UfeBUzVzBJfVo3oWSpbzPurvm7yaCCo2Lk7lVj610HqKw==",
+			"version": "8.64.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.64.0.tgz",
+			"integrity": "sha512-CGvQPBxN3wZLu6Rz2kFUpZeoCm78xUic92ck39KPePkO1NPOwjCqdQnm5Q87tpWw9vcBvW8XLrDXjH9PWYtJ3Q==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@eslint-community/regexpp": "^4.12.2",
-				"@typescript-eslint/scope-manager": "8.60.0",
-				"@typescript-eslint/type-utils": "8.60.0",
-				"@typescript-eslint/utils": "8.60.0",
-				"@typescript-eslint/visitor-keys": "8.60.0",
+				"@typescript-eslint/scope-manager": "8.64.0",
+				"@typescript-eslint/type-utils": "8.64.0",
+				"@typescript-eslint/utils": "8.64.0",
+				"@typescript-eslint/visitor-keys": "8.64.0",
 				"ignore": "^7.0.5",
 				"natural-compare": "^1.4.0",
 				"ts-api-utils": "^2.5.0"
@@ -881,15 +911,15 @@
 				"url": "https://opencollective.com/typescript-eslint"
 			},
 			"peerDependencies": {
-				"@typescript-eslint/parser": "^8.60.0",
+				"@typescript-eslint/parser": "^8.64.0",
 				"eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
 				"typescript": ">=4.8.4 <6.1.0"
 			}
 		},
 		"node_modules/@typescript-eslint/eslint-plugin/node_modules/ignore": {
-			"version": "7.0.5",
-			"resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz",
-			"integrity": "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==",
+			"version": "7.0.6",
+			"resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.6.tgz",
+			"integrity": "sha512-BAg6QkE8W+TuQLrrw0Ugr7HegXduRuuj8/ti2kSOc+jz1dmx8/WNcjr6XGnq5YpDWxFwwaavqD0+jIUOKelTsw==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -897,16 +927,16 @@
 			}
 		},
 		"node_modules/@typescript-eslint/parser": {
-			"version": "8.60.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.60.0.tgz",
-			"integrity": "sha512-fcqpj/MyK4sxDPcbe7STNPbpQL4RLZOPWuaTmwZYuc+hJKzRf58yRxfhqGpc6PIq9ZyfSBpfHgmUHmHs0KwHwg==",
+			"version": "8.64.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.64.0.tgz",
+			"integrity": "sha512-KA0OshtlcCCXmbfqyZkM5pV3/WNraJf7DkJRLpyrmwPtud57H5BDX7C3k0LPSPxpprfRL+cJDGabF10mvNCoCw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@typescript-eslint/scope-manager": "8.60.0",
-				"@typescript-eslint/types": "8.60.0",
-				"@typescript-eslint/typescript-estree": "8.60.0",
-				"@typescript-eslint/visitor-keys": "8.60.0",
+				"@typescript-eslint/scope-manager": "8.64.0",
+				"@typescript-eslint/types": "8.64.0",
+				"@typescript-eslint/typescript-estree": "8.64.0",
+				"@typescript-eslint/visitor-keys": "8.64.0",
 				"debug": "^4.4.3"
 			},
 			"engines": {
@@ -922,14 +952,14 @@
 			}
 		},
 		"node_modules/@typescript-eslint/project-service": {
-			"version": "8.60.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.60.0.tgz",
-			"integrity": "sha512-aZu74NNKJeUWqCjDddzdiKaS82dgYgV/vmf+Ui3ZdZejmgfXR/q+pRumgobnQ2cCJTgGTWp4ypiwsuofFubavg==",
+			"version": "8.64.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.64.0.tgz",
+			"integrity": "sha512-tk4WpOJ6IEbGrVHaNmM0YRrwAD3exZlIK3iadQNAxh4YKk6jvUQ4ecq18n+v7+meh+cJ3j+D8nbk8sRKhlwLQg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@typescript-eslint/tsconfig-utils": "^8.60.0",
-				"@typescript-eslint/types": "^8.60.0",
+				"@typescript-eslint/tsconfig-utils": "^8.64.0",
+				"@typescript-eslint/types": "^8.64.0",
 				"debug": "^4.4.3"
 			},
 			"engines": {
@@ -944,14 +974,14 @@
 			}
 		},
 		"node_modules/@typescript-eslint/scope-manager": {
-			"version": "8.60.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.60.0.tgz",
-			"integrity": "sha512-pFzqhllJMs+jghLQWzV00ds39xLzuyqPSev5pd8f4Ir0rtKR3ZLUB4/4dhjOFighWb9larvtfJvqL+4yKDI3Xw==",
+			"version": "8.64.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.64.0.tgz",
+			"integrity": "sha512-CXEaFdYXjSTgKhisNkwCcJwTP8Pl+fmRrEQrri4nm3vU743bALrxzLmq7fHG/7e6a5xO0lDYeURpZmBuhHk54w==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@typescript-eslint/types": "8.60.0",
-				"@typescript-eslint/visitor-keys": "8.60.0"
+				"@typescript-eslint/types": "8.64.0",
+				"@typescript-eslint/visitor-keys": "8.64.0"
 			},
 			"engines": {
 				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -962,9 +992,9 @@
 			}
 		},
 		"node_modules/@typescript-eslint/tsconfig-utils": {
-			"version": "8.60.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.60.0.tgz",
-			"integrity": "sha512-BZPR3RGYlAXnly6ymAxfkVn5rCbZzQNou0rxv3GfWZ8cTQp+hhVd73khbGLAd8k1TlAPLISH337M+tAgAnaJDQ==",
+			"version": "8.64.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.64.0.tgz",
+			"integrity": "sha512-2yo8rRNKuzbVWQp5kslhANqZ2uDAeROQHBRZNPu8JDsHmeFNj/XJJhX/FhNUWmkHHvoNsKa6+tHJiig87EzsQw==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -979,15 +1009,15 @@
 			}
 		},
 		"node_modules/@typescript-eslint/type-utils": {
-			"version": "8.60.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.60.0.tgz",
-			"integrity": "sha512-SX46wEUtitCpq7AN38HkUU/+zvUpdKf7ephtWAFgckH8O7PQIyL5gvrhQgBLuEYgLfuKWOVvWVskMbuFHAz5xg==",
+			"version": "8.64.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.64.0.tgz",
+			"integrity": "sha512-XWG4Fmmv/6SvyS9nH8jWrKs6terwJvE8cyRt1CzYYqzp9OrPhCT4cMc/f7C6RZCwG+qMmiffJS1/qJP8G1URtg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@typescript-eslint/types": "8.60.0",
-				"@typescript-eslint/typescript-estree": "8.60.0",
-				"@typescript-eslint/utils": "8.60.0",
+				"@typescript-eslint/types": "8.64.0",
+				"@typescript-eslint/typescript-estree": "8.64.0",
+				"@typescript-eslint/utils": "8.64.0",
 				"debug": "^4.4.3",
 				"ts-api-utils": "^2.5.0"
 			},
@@ -1004,9 +1034,9 @@
 			}
 		},
 		"node_modules/@typescript-eslint/types": {
-			"version": "8.60.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.60.0.tgz",
-			"integrity": "sha512-AsE7x2XaAK+CVbeih0Fvbn+r1qHxtpLDJ3XUuFcIinT318T90yHMJC+Zgv+jUuDjQQd06HKwxnDu6sz1IcTilA==",
+			"version": "8.64.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.64.0.tgz",
+			"integrity": "sha512-qjhfuTfLXjA4IOzXvz0rTjT01BqEiIgPoUeMwiEjnaHKJMTNo8rH5pYW1a2L/0Dnux2fPC85AeyJoWaGa8WxTA==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -1018,16 +1048,16 @@
 			}
 		},
 		"node_modules/@typescript-eslint/typescript-estree": {
-			"version": "8.60.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.60.0.tgz",
-			"integrity": "sha512-3AcZNBGMClm6CXDyo8kYvVGT/sx29sS0oBsIb9oZI2gunA4Vm2M3YHzRLPvsUBBsl+yB5FPtltq7gGH0iTlp9g==",
+			"version": "8.64.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.64.0.tgz",
+			"integrity": "sha512-Pztpsn1aCE1oWDvDEfUk31nngvvF7vUB5SwHFEaZIFpvw7WJtqUHHL4plBZDA9HfWJJjL13BdG0YrJInTUvoVA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@typescript-eslint/project-service": "8.60.0",
-				"@typescript-eslint/tsconfig-utils": "8.60.0",
-				"@typescript-eslint/types": "8.60.0",
-				"@typescript-eslint/visitor-keys": "8.60.0",
+				"@typescript-eslint/project-service": "8.64.0",
+				"@typescript-eslint/tsconfig-utils": "8.64.0",
+				"@typescript-eslint/types": "8.64.0",
+				"@typescript-eslint/visitor-keys": "8.64.0",
 				"debug": "^4.4.3",
 				"minimatch": "^10.2.2",
 				"semver": "^7.7.3",
@@ -1056,9 +1086,9 @@
 			}
 		},
 		"node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion": {
-			"version": "5.0.6",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
-			"integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+			"version": "5.0.7",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
+			"integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -1085,9 +1115,9 @@
 			}
 		},
 		"node_modules/@typescript-eslint/typescript-estree/node_modules/semver": {
-			"version": "7.8.1",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-7.8.1.tgz",
-			"integrity": "sha512-rkVq3IXh+4FDGch+KwzX3aV9W3kO54GyEgpvBzSyctDA6Xtd7RJQV1xmXbeQp5v7+VzLOfVqiutSE6GICgPFvg==",
+			"version": "7.8.5",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+			"integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
 			"dev": true,
 			"license": "ISC",
 			"bin": {
@@ -1098,16 +1128,16 @@
 			}
 		},
 		"node_modules/@typescript-eslint/utils": {
-			"version": "8.60.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.60.0.tgz",
-			"integrity": "sha512-HtXuPfrHTyBDkameWpl+vJb1Uevu2tznAyahM1Oc4AENidCLTPiZDWIo4GfcxNdC/RcfGcadzzkqbRG87dUrQA==",
+			"version": "8.64.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.64.0.tgz",
+			"integrity": "sha512-aJUGVB3+U0htrrCjoA8qukw8cm8fNCGAxK/tVoS70k8aeb7DETKeFozRiVFIwEeN9WJLsjaP3ph8I60tY2XZoQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@eslint-community/eslint-utils": "^4.9.1",
-				"@typescript-eslint/scope-manager": "8.60.0",
-				"@typescript-eslint/types": "8.60.0",
-				"@typescript-eslint/typescript-estree": "8.60.0"
+				"@typescript-eslint/scope-manager": "8.64.0",
+				"@typescript-eslint/types": "8.64.0",
+				"@typescript-eslint/typescript-estree": "8.64.0"
 			},
 			"engines": {
 				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -1122,13 +1152,13 @@
 			}
 		},
 		"node_modules/@typescript-eslint/visitor-keys": {
-			"version": "8.60.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.60.0.tgz",
-			"integrity": "sha512-9WI52t8ZGLVGrPMBet25yAftqY/n95+zmoUUtJBBQTKDSKUu7OsPTroT2op7U9JatkoRccL0YkWDNMFfC4Sjxg==",
+			"version": "8.64.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.64.0.tgz",
+			"integrity": "sha512-mrtuL8Nsn6gi2H4mo5KMTp823M+3Q19Ew/i+Zlikq20tIMm99C3Ez0dCmkWWnxut20esQvTg8aUSEhMcAOXhEw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@typescript-eslint/types": "8.60.0",
+				"@typescript-eslint/types": "8.64.0",
 				"eslint-visitor-keys": "^5.0.0"
 			},
 			"engines": {
@@ -1891,9 +1921,9 @@
 			}
 		},
 		"node_modules/esbuild": {
-			"version": "0.28.0",
-			"resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.0.tgz",
-			"integrity": "sha512-sNR9MHpXSUV/XB4zmsFKN+QgVG82Cc7+/aaxJ8Adi8hyOac+EXptIp45QBPaVyX3N70664wRbTcLTOemCAnyqw==",
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.1.tgz",
+			"integrity": "sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==",
 			"dev": true,
 			"hasInstallScript": true,
 			"license": "MIT",
@@ -1904,32 +1934,32 @@
 				"node": ">=18"
 			},
 			"optionalDependencies": {
-				"@esbuild/aix-ppc64": "0.28.0",
-				"@esbuild/android-arm": "0.28.0",
-				"@esbuild/android-arm64": "0.28.0",
-				"@esbuild/android-x64": "0.28.0",
-				"@esbuild/darwin-arm64": "0.28.0",
-				"@esbuild/darwin-x64": "0.28.0",
-				"@esbuild/freebsd-arm64": "0.28.0",
-				"@esbuild/freebsd-x64": "0.28.0",
-				"@esbuild/linux-arm": "0.28.0",
-				"@esbuild/linux-arm64": "0.28.0",
-				"@esbuild/linux-ia32": "0.28.0",
-				"@esbuild/linux-loong64": "0.28.0",
-				"@esbuild/linux-mips64el": "0.28.0",
-				"@esbuild/linux-ppc64": "0.28.0",
-				"@esbuild/linux-riscv64": "0.28.0",
-				"@esbuild/linux-s390x": "0.28.0",
-				"@esbuild/linux-x64": "0.28.0",
-				"@esbuild/netbsd-arm64": "0.28.0",
-				"@esbuild/netbsd-x64": "0.28.0",
-				"@esbuild/openbsd-arm64": "0.28.0",
-				"@esbuild/openbsd-x64": "0.28.0",
-				"@esbuild/openharmony-arm64": "0.28.0",
-				"@esbuild/sunos-x64": "0.28.0",
-				"@esbuild/win32-arm64": "0.28.0",
-				"@esbuild/win32-ia32": "0.28.0",
-				"@esbuild/win32-x64": "0.28.0"
+				"@esbuild/aix-ppc64": "0.28.1",
+				"@esbuild/android-arm": "0.28.1",
+				"@esbuild/android-arm64": "0.28.1",
+				"@esbuild/android-x64": "0.28.1",
+				"@esbuild/darwin-arm64": "0.28.1",
+				"@esbuild/darwin-x64": "0.28.1",
+				"@esbuild/freebsd-arm64": "0.28.1",
+				"@esbuild/freebsd-x64": "0.28.1",
+				"@esbuild/linux-arm": "0.28.1",
+				"@esbuild/linux-arm64": "0.28.1",
+				"@esbuild/linux-ia32": "0.28.1",
+				"@esbuild/linux-loong64": "0.28.1",
+				"@esbuild/linux-mips64el": "0.28.1",
+				"@esbuild/linux-ppc64": "0.28.1",
+				"@esbuild/linux-riscv64": "0.28.1",
+				"@esbuild/linux-s390x": "0.28.1",
+				"@esbuild/linux-x64": "0.28.1",
+				"@esbuild/netbsd-arm64": "0.28.1",
+				"@esbuild/netbsd-x64": "0.28.1",
+				"@esbuild/openbsd-arm64": "0.28.1",
+				"@esbuild/openbsd-x64": "0.28.1",
+				"@esbuild/openharmony-arm64": "0.28.1",
+				"@esbuild/sunos-x64": "0.28.1",
+				"@esbuild/win32-arm64": "0.28.1",
+				"@esbuild/win32-ia32": "0.28.1",
+				"@esbuild/win32-x64": "0.28.1"
 			}
 		},
 		"node_modules/escape-string-regexp": {
@@ -2343,12 +2373,13 @@
 			}
 		},
 		"node_modules/eslint-plugin-obsidianmd": {
-			"version": "0.3.0",
-			"resolved": "https://registry.npmjs.org/eslint-plugin-obsidianmd/-/eslint-plugin-obsidianmd-0.3.0.tgz",
-			"integrity": "sha512-QvGDI6B2nxJBrsZKGTg31da2A/fEJNlnwN+fRZkaoPIu1QL3fYXUdpP7ThyMdr/0iTYQxifb9lt2X9cpydQx1w==",
+			"version": "0.4.1",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-obsidianmd/-/eslint-plugin-obsidianmd-0.4.1.tgz",
+			"integrity": "sha512-Nv3593kVsFOS8kir/HWaJ5CR3xcyiPWEPyXst5Pib8mxRYYuLYPpJS2ALMoZXHulHyiGwoYW8AaxvLRc4rhrRg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
+				"@eslint-community/eslint-plugin-eslint-comments": "^4.7.2",
 				"@eslint/config-helpers": "^0.4.2",
 				"@eslint/js": "^9.30.1",
 				"@eslint/json": "0.14.0",
@@ -2357,7 +2388,7 @@
 				"@types/node": "20.12.12",
 				"@typescript-eslint/types": "^8.33.1",
 				"@typescript-eslint/utils": "^8.33.1",
-				"eslint": ">=9.0.0",
+				"eslint": ">=9.19.0",
 				"eslint-plugin-depend": "1.3.1",
 				"eslint-plugin-import": "^2.31.0",
 				"eslint-plugin-json-schema-validator": "5.1.0",
@@ -2378,7 +2409,7 @@
 			"peerDependencies": {
 				"@eslint/js": "^9.30.1",
 				"@eslint/json": "0.14.0",
-				"eslint": ">=9.0.0",
+				"eslint": ">=9.19.0",
 				"obsidian": "1.8.7",
 				"typescript-eslint": "^8.35.1"
 			}
@@ -3905,9 +3936,9 @@
 			}
 		},
 		"node_modules/obsidian": {
-			"version": "1.13.0",
-			"resolved": "https://registry.npmjs.org/obsidian/-/obsidian-1.13.0.tgz",
-			"integrity": "sha512-PHw5+SAPlJ0S3leFvJ0wgFg63Z3DavxL6+d1ll+8toXR2ZlYKc1rMWqdUv9LgUbTwPQUyY6yfhOMMivampRRiQ==",
+			"version": "1.13.1",
+			"resolved": "https://registry.npmjs.org/obsidian/-/obsidian-1.13.1.tgz",
+			"integrity": "sha512-qtTEA2pmhJzhuhJqzbBFRYhpIOqvW+krDYjtFynv66KbxBbumHBlsJfWw3I4jtnK/6fZwbQhCrmmDdRwXmX56w==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -4846,16 +4877,16 @@
 			}
 		},
 		"node_modules/typescript-eslint": {
-			"version": "8.60.0",
-			"resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.60.0.tgz",
-			"integrity": "sha512-9f65qWLZdAW9m1JaxBDUHcqRUfL8bkxxXL7XxEfI+F09q56PkBvIfCjLF3yInsDM/BBmwkqmCQdCZe/RYlIWEw==",
+			"version": "8.64.0",
+			"resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.64.0.tgz",
+			"integrity": "sha512-0qg+pDNMnqYzqH9AnNK+39tejHvsShUOUUoRUgtnTGE7QuMZhiFDnozq8nHJVq+Wae6NMLKNWLg5WmkcC/ndyQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@typescript-eslint/eslint-plugin": "8.60.0",
-				"@typescript-eslint/parser": "8.60.0",
-				"@typescript-eslint/typescript-estree": "8.60.0",
-				"@typescript-eslint/utils": "8.60.0"
+				"@typescript-eslint/eslint-plugin": "8.64.0",
+				"@typescript-eslint/parser": "8.64.0",
+				"@typescript-eslint/typescript-estree": "8.64.0",
+				"@typescript-eslint/utils": "8.64.0"
 			},
 			"engines": {
 				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"

--- a/package.json
+++ b/package.json
@@ -13,14 +13,17 @@
 	"keywords": [],
 	"license": "MIT",
 	"devDependencies": {
-		"@eslint/js": "9.39.4",
-		"@types/node": "^25.9.1",
-		"esbuild": "0.28.0",
-		"eslint-plugin-obsidianmd": "0.3.0",
+		"@eslint/js": "9.39.5",
+		"@types/node": "^26.1.1",
+		"esbuild": "0.28.1",
+		"eslint-plugin-obsidianmd": "0.4.1",
 		"jiti": "2.7.0",
-		"obsidian": "1.13.0",
+		"obsidian": "1.13.1",
 		"tslib": "2.8.1",
 		"typescript": "6.0.3",
-		"typescript-eslint": "8.60.0"
+		"typescript-eslint": "8.64.0"
+	},
+	"allowScripts": {
+		"esbuild@0.28.1": true
 	}
 }

--- a/src/bulk-edit-modal.ts
+++ b/src/bulk-edit-modal.ts
@@ -438,35 +438,35 @@ export class BulkEditModal extends Modal {
 				break;
 
 			case "number": {
-				const numInput = setting.controlEl.ownerDocument.createElement("input");
-				numInput.type = "number";
-				numInput.className = "bulk-properties-number-input";
+				const numInput = setting.controlEl.createEl("input", {
+					type: "number",
+					cls: "bulk-properties-number-input",
+				});
 				numInput.addEventListener("input", () => {
 					this.rawValue = numInput.value;
 				});
-				setting.controlEl.appendChild(numInput);
 				break;
 			}
 
 			case "date": {
-				const dateInput = setting.controlEl.ownerDocument.createElement("input");
-				dateInput.type = "date";
-				dateInput.className = "bulk-properties-date-input";
+				const dateInput = setting.controlEl.createEl("input", {
+					type: "date",
+					cls: "bulk-properties-date-input",
+				});
 				dateInput.addEventListener("input", () => {
 					this.rawValue = dateInput.value;
 				});
-				setting.controlEl.appendChild(dateInput);
 				break;
 			}
 
 			case "datetime": {
-				const dtInput = setting.controlEl.ownerDocument.createElement("input");
-				dtInput.type = "datetime-local";
-				dtInput.className = "bulk-properties-date-input";
+				const dtInput = setting.controlEl.createEl("input", {
+					type: "datetime-local",
+					cls: "bulk-properties-date-input",
+				});
 				dtInput.addEventListener("input", () => {
 					this.rawValue = dtInput.value;
 				});
-				setting.controlEl.appendChild(dtInput);
 				break;
 			}
 

--- a/src/confirm-modal.ts
+++ b/src/confirm-modal.ts
@@ -32,8 +32,7 @@ class ConfirmModal extends Modal {
 			.addButton(btn => {
 				btn.setButtonText(this.confirmText);
 				if (this.confirmStyle === "warning") {
-					// eslint-disable-next-line @typescript-eslint/no-deprecated -- setDestructive() requires Obsidian 1.13.0; setWarning keeps minAppVersion at 1.8.7
-					btn.setWarning();
+					btn.setDestructive();
 				} else {
 					btn.setCta();
 				}

--- a/src/remove-selection-property.ts
+++ b/src/remove-selection-property.ts
@@ -43,8 +43,7 @@ class ConfirmRemoveModal extends Modal {
 				.onClick(() => this.close()))
 			.addButton(btn => btn
 				.setButtonText("Remove")
-				// eslint-disable-next-line @typescript-eslint/no-deprecated -- setDestructive() requires Obsidian 1.13.0; setWarning keeps minAppVersion at 1.8.7
-				.setWarning()
+				.setDestructive()
 				.onClick(() => {
 					this.confirmed = true;
 					this.close();

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -149,15 +149,6 @@ export class BulkPropertiesSettingTab extends PluginSettingTab {
 		}
 	}
 
-	// The imperative display() API is deprecated since Obsidian 1.13.0 in favour
-	// of declarative getSettingDefinitions(), but it remains fully supported.
-	// We intentionally keep the imperative model; this helper centralises the
-	// re-render so the single deprecation suppression lives in one place.
-	private rerender(): void {
-		// eslint-disable-next-line @typescript-eslint/no-deprecated -- imperative settings API still supported; see note above
-		this.display();
-	}
-
 	override display(): void {
 		const {containerEl} = this;
 		containerEl.empty();
@@ -318,7 +309,7 @@ export class BulkPropertiesSettingTab extends PluginSettingTab {
 							(_, idx) => idx !== i,
 						);
 						if (await this.updateSetting("properties", updated)) {
-							this.rerender();
+							this.update();
 						}
 					}));
 		}
@@ -417,7 +408,7 @@ export class BulkPropertiesSettingTab extends PluginSettingTab {
 							{name: newName, type: newType},
 						];
 						if (await this.updateSetting("properties", updated)) {
-							this.rerender();
+							this.update();
 						}
 					});
 			});


### PR DESCRIPTION
## Summary
- Update devDependencies to latest releases: @eslint/js 9.39.5, @types/node 26.1.1, esbuild 0.28.1, eslint-plugin-obsidianmd 0.4.1, obsidian 1.13.1, typescript-eslint 8.64.0
- Held back: @eslint/js 10 (eslint-plugin-obsidianmd peer-pins ^9.30.1) and TypeScript 7 (typescript-eslint requires <6.1.0)
- Bump minAppVersion to 1.13.0 and replace deprecated API usage with the 1.13 equivalents, removing all @typescript-eslint/no-deprecated suppressions (Obsidian's plugin check rejects disable comments for that rule):
  - ButtonComponent.setWarning() → setDestructive() in confirm-modal.ts and remove-selection-property.ts
  - Settings tab internal re-render now calls SettingPage.update() instead of the deprecated this.display(); the rerender() helper that existed to hold the suppression is removed
  - The imperative display() settings model is kept for now; migrating to getSettingDefinitions() is planned as a follow-up. obsidianmd/settings-tab/prefer-setting-definitions is turned off in eslint.config.mts with a comment.
- Fix obsidianmd/prefer-create-el warnings in bulk-edit-modal.ts by using controlEl.createEl() instead of ownerDocument.createElement()
- Approve esbuild 0.28.1 postinstall script under the allowScripts policy

Users on Obsidian < 1.13.0 remain on plugin 1.0.10 via the versions.json fallback once the next release is published.

## Test plan
- `npm run build` passes (tsc + esbuild)
- `npm run lint` passes with no errors or warnings
- `npm audit` reports 0 vulnerabilities
- Manual smoke test in vault: destructive buttons render with warning styling; adding/removing a configured property refreshes the settings tab via update()