### PR TITLE
Restore properties guidance text lost in declarative migration

### DIFF
--- a/src/settings.ts
+++ b/src/settings.ts
@@ -64,7 +64,18 @@ export class BulkPropertiesSettingTab extends PluginSettingTab {
 			{
 				type: "list",
 				heading: "Properties",
-				emptyState: "No properties configured. Add at least one property to use the bulk-editing feature.",
+				// The declarative API has no slot for text under a group
+				// heading, so the guidance the imperative tab showed there
+				// lives in the empty state — shown exactly when it applies.
+				emptyState: createFragment(fragment => {
+					fragment.appendText(
+						"Configure which properties are available for bulk editing.",
+					);
+					fragment.createEl("br");
+					fragment.createEl("strong", {
+						text: "You must add at least one property to use the bulk-editing feature.",
+					});
+				}),
 				addItem: {
 					name: "Add property",
 					action: () => {


### PR DESCRIPTION
## What

Restores the two lines of guidance that sat under the **Properties** heading before the declarative settings migration (#59):

- "Configure which properties are available for bulk editing."
- **"You must add at least one property to use the bulk-editing feature."** (bold)

Both sentences now render as the property list's empty state (a `DocumentFragment` with the second line in `<strong>`), replacing the previous single-sentence string. They appear when the list is empty — exactly when the mandatory-property warning applies.

## Why the empty state

Verified against `obsidian.d.ts` 1.13.1 and the Obsidian 1.13.4 app bundle:

- `SettingDefinitionGroup`/`SettingDefinitionList` have no `desc` field, and the group header DOM contains only a name div and a control div — there is no description container, so the old heading-with-desc pattern has no declarative equivalent.
- A static text row can't live inside the list's `items`: with `onDelete`/`onReorder` set, every child row gets an X button and a drag handle, and delete indices resolve across all rows in the group.
- A desc-only row placed before the list would render above the heading, inside its own bordered card in the 1.13 group design.

When the list is non-empty the warning is moot and the populated list is self-describing, so no always-visible text is added.

## Testing

`npm run build` and `npm run lint` pass. Needs a visual check in the vault: with no properties configured, the Properties list should show both lines (second bold) as muted text; adding a property should replace them with the property row.

Closes #60